### PR TITLE
增加数学库使用，支持mpirun，修改位置

### DIFF
--- a/Development_framework/hpc-sdk/build/build.sh
+++ b/Development_framework/hpc-sdk/build/build.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+
+# Copyright 2022 Huawei Technologies Co., Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+current_dir=$(
+  cd $(dirname $0)
+  pwd
+)
+WORKSPACE=${current_dir}/output
+opensource_dir=${current_dir}/opensource
+[[ -d "${WORKSPACE}" ]] && { rm -rf ${WORKSPACE};mkdir -p ${WORKSPACE}; } || mkdir -p ${WORKSPACE}
+[[ -d "${opensource_dir}" ]] && { rm -rf ${opensource_dir};mkdir -p ${opensource_dir}; } || mkdir -p ${opensource_dir}
+# Read the configuration file to get the LAPACK package address
+lib_klapack_name=$(sed '/^lib_klapack_name=/!d;s/.*=//;s/\r//' ${current_dir}/const.conf)
+# Read the configuration file to obtain the package information to be downloaded
+all_need_download_softwares=$(sed '/^all_need_download_softwares=/!d;s/.*=//;s/\r//' ${current_dir}/const.conf)
+hpc_kunpeng_package_name=$(sed '/^hpc_kunpeng_package_name=/!d;s/.*=//;s/\r//' ${current_dir}/const.conf)
+
+check_dos2unix(){
+    dos2unix -V >/dev/null 2>&1
+    if [[  "$?" -ne 0 ]];then
+        yum install -y dos2unix
+        if [[  "$?" -ne 0 ]];then
+            apt install dos2unix -y
+        fi
+    fi
+}
+
+compiler_libklapack(){
+    download_package "${opensource_dir}" "${lib_klapack_name}"
+    netlib=${opensource_dir}/v3.9.1.tar.gz
+    klapack=/usr/local/kml/lib/libklapack.a
+    cd ${opensource_dir}
+    mkdir lapack_adapt
+    cd lapack_adapt
+
+    # build netlib lapack
+    mkdir netlib
+    cd netlib
+    tar -xf ${netlib}
+    mkdir build
+    cd build
+    cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_POSITION_INDEPENDENT_CODE=ON ../lapack-3.9.1
+    make -j $(lscpu | grep "^CPU(s):" | awk '{print $2}')
+    cd ../..
+
+    cp netlib/build/lib/libblas.a ${WORKSPACE}/${hpc_kunpeng_package_name}/package/kml
+    cp netlib/build/lib/liblapack.a  ${WORKSPACE}/${hpc_kunpeng_package_name}/package/kml/liblapack_adapt.a
+}
+
+download_package()
+{
+    local package_dir="$1"
+    local url="$2"
+    mkdir -p "${package_dir}"
+    cd "${package_dir}"
+    wget "${url}" -t 10 --no-check-certificate
+    if [[ "$?" -ne 0 ]];then
+        echo "Download ${url} Failed"
+        exit 1
+    fi
+}
+
+rm_path()
+{
+    local directory="$1"
+    [[ -d "${directory}" ]] && rm -rf "${directory}"
+}
+
+rm_file()
+{
+    local filename="$1"
+    [[ -f "${filename}" ]] && rm -rf "${filename}"
+}
+
+check_dos2unix
+cd ${WORKSPACE}
+rm_path "${WORKSPACE}/${hpc_kunpeng_package_name}"
+rm_file "${WORKSPACE}/${hpc_kunpeng_package_name}.tar.gz"
+rm_file "${hpc_kunpeng_package_name}.sha256sum"
+
+split_software_info(){
+    local software_name="$1"
+    software_infos=$(sed "/^${software_name}=/!d;s/.*=//;s/\r//" ${current_dir}/const.conf)
+    software_infos=(${software_infos//;/ })
+    package=${software_infos[0]}
+    url=${software_infos[1]}
+}
+
+download_software_common_func()
+{
+    for software in $(echo ${all_need_download_softwares//;/ })
+    do
+        split_software_info "${software}"
+        {
+            download_package "${WORKSPACE}/${hpc_kunpeng_package_name}/package/${package}" "${url}"
+        }&
+    done
+    wait
+}
+
+clean()
+{
+    # clean
+    rm_path "${hpc_kunpeng_package_name}"
+    rm_path "${opensource_dir}"
+}
+
+packing()
+{
+    cd ${WORKSPACE}/${hpc_kunpeng_package_name}/package/kml && unzip *.zip && rm_file *.zip
+    cp -rf ${current_dir}/../script ${WORKSPACE}/${hpc_kunpeng_package_name}
+    cp -rf ${current_dir}/../module ${WORKSPACE}/${hpc_kunpeng_package_name}
+    mv ${WORKSPACE}/${hpc_kunpeng_package_name}/script/README*.md ${WORKSPACE}/${hpc_kunpeng_package_name}
+    # modifying per,ossions
+    find ${WORKSPACE}/${hpc_kunpeng_package_name} -type d | xargs chmod 755
+    find ${WORKSPACE}/${hpc_kunpeng_package_name}/package -type f | xargs chmod 644
+    chmod 644 ${WORKSPACE}/${hpc_kunpeng_package_name}/README*.md 
+    chmod 644 ${WORKSPACE}/${hpc_kunpeng_package_name}/module/* 
+    chmod 555 ${WORKSPACE}/${hpc_kunpeng_package_name}/script/*.sh
+    chmod 644 ${WORKSPACE}/${hpc_kunpeng_package_name}/script/*.conf
+    cd ${WORKSPACE}
+    find ${WORKSPACE}/${hpc_kunpeng_package_name} -type f | xargs dos2unix 
+    tar -cvf ${hpc_kunpeng_package_name}.tar.gz ${hpc_kunpeng_package_name}
+    sha256sum ${hpc_kunpeng_package_name}.tar.gz > ${hpc_kunpeng_package_name}.sha256sum
+}
+
+download_software_common_func
+
+compiler_libklapack
+
+packing
+
+clean

--- a/Development_framework/hpc-sdk/build/const.conf
+++ b/Development_framework/hpc-sdk/build/const.conf
@@ -1,0 +1,15 @@
+# version
+package_version=1.0.0
+# package name
+hpc_kunpeng_package_name=kunpeng-hpc-1.0.0-aarch64-linux
+# pakage_url
+all_need_download_softwares=kylinv10_linux_hmpi_gcc;kylinv10_linux_hmpi_bisheng;centos7.6_linux_hmpi_gcc;centos7.6_linux_hmpi_bisheng;openeuler20.03_lts_linux_hmpi_bisheng;bisheng_compiler;gcc_compiler;library_math
+kylinv10_linux_hmpi_gcc=hyper_mpi;https://mirrors.huaweicloud.com/kunpeng/archive/HyperMPI/1.1.1/Hyper-MPI_1.1.1_aarch64_KylinV10SP2_gcc9.3.0_MLNX-OFED5.4.tar.gz
+kylinv10_linux_hmpi_bisheng=hyper_mpi;https://mirrors.huaweicloud.com/kunpeng/archive/HyperMPI/1.1.1/Hyper-MPI_1.1.1_aarch64_KylinV10SP2_Bisheng2.1.0_MLNX-OFED5.4.tar.gz
+centos7.6_linux_hmpi_gcc=hyper_mpi;https://mirrors.huaweicloud.com/kunpeng/archive/HyperMPI/1.1.1/Hyper-MPI_1.1.1_aarch64_CentOS7.6_GCC9.3_MLNX-OFED5.0.tar.gz
+centos7.6_linux_hmpi_bisheng=hyper_mpi;https://mirrors.huaweicloud.com/kunpeng/archive/HyperMPI/1.1.1/Hyper-MPI_1.1.1_aarch64_CentOS7.6_Bisheng2.1.0_MLNX-OFED5.0.tar.gz
+openeuler20.03_lts_linux_hmpi_bisheng=hyper_mpi;https://mirrors.huaweicloud.com/kunpeng/archive/HyperMPI/1.1.1/Hyper-MPI_1.1.1_aarch64_OpenEuler20.03-LTS_Bisheng2.1.0_MLNX-OFED5.4.tar.gz
+bisheng_compiler=bisheng;https://mirrors.huaweicloud.com/kunpeng/archive/compiler/bisheng_compiler/bisheng-compiler-2.1.0-aarch64-linux.tar.gz
+gcc_compiler=gcc;https://mirror.iscas.ac.cn/kunpeng/archive/compiler/kunpeng_gcc/gcc-10.3.1-2021.09-aarch64-linux.tar.gz
+library_math=kml;https://kunpeng-repo.obs.cn-north-4.myhuaweicloud.com/Kunpeng%20BoostKit/Kunpeng%20BoostKit%2022.0.RC3/BoostKit-kml_1.6.0.zip
+lib_klapack_name=https://github.com/Reference-LAPACK/lapack/archive/v3.9.1.tar.gz

--- a/Development_framework/hpc-sdk/examples/helloworld/CMakeLists.txt
+++ b/Development_framework/hpc-sdk/examples/helloworld/CMakeLists.txt
@@ -1,0 +1,39 @@
+# Copyright 2022 Huawei Technologies Co., Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 2.8)
+
+project(hello_world C)
+
+# Add source files
+set(SRC src/hello_world.c)
+
+# Set target file
+set(TARGET_FILE hello_world)
+
+# Set Compiler
+set(CMAKE_C_COMPILER mpicc)
+
+# Default build type is debug
+set(CMAKE_BUILD_TYPE "Debug")
+
+if(${CMAKE_BUILD_TYPE} STREQUAL "Debug")
+    add_compile_options(-g -o)
+endif()
+
+# Add openmp option
+add_compile_options(-fopenmp)
+
+# Generate execute file
+add_executable(${TARGET_FILE} ${SRC})

--- a/Development_framework/hpc-sdk/examples/helloworld/README.md
+++ b/Development_framework/hpc-sdk/examples/helloworld/README.md
@@ -1,0 +1,52 @@
+# **HPC sample demo**
+
+简体中文 | [English](README_en.md)
+
+## 介绍
+
+1. 提供HPC场景Hello world工程；
+2. 通过鲲鹏开发框架创建该工程，samples目录下会包含所有kml demo工程，供开发者参考。
+
+## 使用依赖
+
+1. 通过[HPC SDK](https://mirrors.huaweicloud.com/kunpeng/archive/Kunpeng_SDK/HPC/)安装HMPI库，编译器，数学库。
+
+## 使用教程
+
+
+1. 获取代码
+
+   ```shell
+   git clone https://github.com/kunpengcompute/devkitdemo.git
+   ```
+
+2. 切入到项目根路径
+
+   ```shell
+   cd ./devkitdemo/Development_framework/hpc-sdk/examples/examples/helloworld/
+   ```
+
+3. 编译demo
+
+   ```shell
+   mkdir build
+   cd build
+   cmake ..
+   make
+   ```
+
+4. 运行demo
+
+   ```shell
+   # 单独执行
+   ./hello_world
+   # mpirun 执行
+   mpirun -n rank数 hello_world
+   ```
+
+5. 清理demo
+
+   ```shell
+   cd ..
+   rm -rf build
+   ```

--- a/Development_framework/hpc-sdk/examples/helloworld/README_en.md
+++ b/Development_framework/hpc-sdk/examples/helloworld/README_en.md
@@ -1,0 +1,52 @@
+# **HPC sample demo**
+
+English | [简体中文](README.md)
+
+## Introduction
+
+1. Provide the Hello World project in the HPC scenario.
+2. When a project is created using the Kunpeng Development Framework Plugin, the samples directory provides all kml demo projects for reference.
+
+## Dependencies
+
+1. Using the [HPC SDK](https://mirrors.huaweicloud.com/kunpeng/archive/Kunpeng_SDK/HPC/) to install the HMPI library, compiler, and math library.
+
+## Guidance
+
+
+1. Obtain the code.
+
+   ```shell
+   git clone https://github.com/kunpengcompute/devkitdemo.git
+   ```
+
+2. Switch to the project root path.
+
+   ```shell
+   cd ./devkitdemo/Development_framework/hpc-sdk/examples/examples/helloworld/
+   ```
+
+3. Compile the demo.
+
+   ```shell
+   mkdir build
+   cd build
+   cmake ..
+   make
+   ```
+
+4. Run the demo.
+
+   ```shell
+   # Run the demo independently.
+   ./hello_world
+   # Run the demo using the mpirun command.
+   mpirun -n rank numbers hello_world
+   ```
+
+5. Clean up the demo.
+
+   ```shell
+   cd ..
+   rm -rf build
+   ```

--- a/Development_framework/hpc-sdk/examples/helloworld/src/hello_world.c
+++ b/Development_framework/hpc-sdk/examples/helloworld/src/hello_world.c
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022 Huawei Technologies Co., Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http: //www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * Description:
+ * 		A sample demo. Sample directory contains all kml demos. 
+ * Create: 2022-11-21
+ */
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <mpi.h>
+
+ int main()
+ {
+    MPI_Init(NULL, NULL);
+    printf("Hello world.\n");
+    MPI_Finalize();
+    return EXIT_SUCCESS;
+ }

--- a/Development_framework/hpc-sdk/examples/hmpi/bcast/CMakeLists.txt
+++ b/Development_framework/hpc-sdk/examples/hmpi/bcast/CMakeLists.txt
@@ -1,0 +1,31 @@
+# Copyright 2022 Huawei Technologies Co., Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 2.8)
+project(hmpi_demo C)
+
+# Add source files
+set(SRC src/bcast_demo.c)
+
+# Set target file
+set(TARGET_FILE bcast_demo)
+
+# Set Compiler
+set(CMAKE_C_COMPILER mpicc)
+
+# Add openmp option
+add_compile_options(-fopenmp)
+
+# Generate execute file
+add_executable(${TARGET_FILE} ${SRC})

--- a/Development_framework/hpc-sdk/examples/hmpi/bcast/README.md
+++ b/Development_framework/hpc-sdk/examples/hmpi/bcast/README.md
@@ -1,0 +1,64 @@
+# **Hyper MPI broadcast functions demo**
+
+简体中文 | [English](README_en.md)
+
+## 介绍
+
+1. [Hyper MPI](https://www.hikunpeng.com/developer/hpc/hypermpi)
+   是整个高性能计算解决方案的关键组件，它实现了并行计算的网络通讯功能，可以用来支持制造、气象、超算中心等应用场景，同时该通信库也可扩展应用于AI、大数据等通用领域。Message Passing
+   Interface（MPI）是支持多编程语言编程的并行计算通讯应用接口，具有高性能、大规模性、可移植性、可扩展性等特点。
+2. [Hyper MPI](https://www.hikunpeng.com/developer/hpc/hypermpi) 是基于Open MPI 4.1.1和Open UCX
+   1.10.1，支持MPI-V3.1标准的并行计算API接口，新增了优化的集合通信框架。同时，Hyper MPI对数据密集型和高性能计算提供了网络加速能力，使能了节点间高速通信网络和节点内共享内存机制，以及优化的集合通信算法。Hyper
+   MPI的COLL UCX通信框架能够支持的最大数据包长度为2^32字节。
+3. **Hyper MPI broadcast functions demo** 用于展示对MPI_Bcast集合通信的优化。
+
+## 使用依赖
+
+1. 确保已安装 **Hyper MPI 1.1.1**
+2. 确保已安装 **HMPI** 对应版本的编译器：**GCC 9.3.0** 或 **BiSheng 2.1.0**
+
+## 使用教程
+
+1. 获取代码
+
+   ```shell
+   git clone https://github.com/kunpengcompute/devkitdemo.git
+   ```
+
+2. 切入到项目根路径
+
+   ```shell
+   cd ./devkitdemo/hpc-sdk/examples/hmpi/bcast/
+   ```
+
+3. 编译demo
+
+   ```shell
+   mkdir build
+   cd build
+   cmake ..
+   make
+   ```
+
+4. 运行demo
+
+   ```shell
+   # 使用普通用户执行
+   mpirun -n 4 bcast_demo
+   # 使用普通用户执行，并屏蔽掉coll ucx
+   mpirun -n 4 -mca coll ^ucx bcast_demo
+   ```
+
+5. 清理demo
+
+   ```shell
+   cd ..
+   rm -rf build
+   ```
+
+## 命令参考链接
+
+1. [Non-coll模式](https://www.hikunpeng.com/document/detail/zh/kunpenghpcs/hypermpi/userg_huaweimpi_0014.html)
+2. [Coll模式](https://www.hikunpeng.com/document/detail/zh/kunpenghpcs/hypermpi/userg_huaweimpi_0015.html)
+3. [集合操作算法选择说明](https://www.hikunpeng.com/document/detail/zh/kunpenghpcs/hypermpi/userg_huaweimpi_0016.html)
+4. [命令说明及示例](https://www.hikunpeng.com/document/detail/zh/kunpenghpcs/hypermpi/userg_huaweimpi_0031.html)

--- a/Development_framework/hpc-sdk/examples/hmpi/bcast/README_en.md
+++ b/Development_framework/hpc-sdk/examples/hmpi/bcast/README_en.md
@@ -1,0 +1,68 @@
+# **Hyper MPI broadcast functions demo**
+
+English | [简体中文](README.md)
+
+## Introduction
+
+1. [Hyper MPI](https://www.hikunpeng.com/en/developer/hpc/hypermpi) is key to the HPC solution. It implements network
+   communication for parallel computing and is applicable to manufacturing, meteorology, supercomputing, AI, and big
+   data. Message Passing Interface (MPI) supports multi-language programming, featuring high performance, large scale,
+   portability, and scalability.
+2. [Hyper MPI](https://www.hikunpeng.com/en/developer/hpc/hypermpi) based on Open MPI 4.1.1 and Open UCX 1.10.1, Hyper
+   MPI supports the parallel computing API interface of the MPI-V3.1 standard, and optimizes the collection
+   communication framework. In addition, Hyper MPI accelerates the network for data-intensive and high-performance
+   computing, and enables a high-speed communication network and shared memory mechanism between nodes, and an optimized
+   collection communication algorithm. The maximum data packet length supported by the COLL UCX communication framework
+   of Hyper MPI is 232 bytes.
+3. The **Hyper MPI broadcast functions demo** shows a code example of MPI_Bcast.
+
+## Dependencies
+
+1. Ensure that **Hyper MPI 1.1.1** has been installed.
+2. Ensure that **GCC 9.3.0** or **BiSheng 2.1.0** has been installed.
+
+## Guidance
+
+1. Obtain the code.
+
+   ```shell
+   git clone https://github.com/kunpengcompute/devkitdemo.git
+   ```
+
+2. Switch to the project root path.
+
+   ```shell
+   cd ./devkitdemo/hpc-sdk/examples/hmpi/bcast/
+   ```
+
+3. Compile the demo.
+
+   ```shell
+   mkdir build
+   cd build
+   cmake ..
+   make
+   ```
+
+4. Run the demo.
+
+   ```shell
+   # Non-root user run demo.
+   mpirun -n 4 bcast_demo
+   # non-root user run demo with non-coll mode.
+   mpirun -n 4 -mca coll ^ucx bcast_demo
+   ```
+
+5. Clean up the demo.
+
+   ```shell
+   cd ..
+   rm -rf build
+   ```
+
+## Command Reference Link
+
+1. [Non-coll Mode](https://support.huaweicloud.com/intl/en-us/usermanual-kunpenghpcs/userg_huaweimpi_0014.html)
+2. [Coll Mode](https://support.huaweicloud.com/intl/en-us/usermanual-kunpenghpcs/userg_huaweimpi_0015.html)
+3. [Algorithm Selection for Set Operations](https://support.huaweicloud.com/intl/en-us/usermanual-kunpenghpcs/userg_huaweimpi_0016.html)
+4. [Command Description and Example](https://support.huaweicloud.com/intl/en-us/usermanual-kunpenghpcs/userg_huaweimpi_0031.html)

--- a/Development_framework/hpc-sdk/examples/hmpi/bcast/src/bcast_demo.c
+++ b/Development_framework/hpc-sdk/examples/hmpi/bcast/src/bcast_demo.c
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2022 Huawei Technologies Co., Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http: //www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * Description: KML blas library demo
+ * Refrence: www.mpitutorial.com
+ * Create: 2022-05-17
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <mpi.h>
+
+int InputParameterParse(int argc, char** argv)
+{
+	if (argc == 1)
+	{
+		return 0;
+	}
+	// Parameter must be 1
+	printf("Invalid parameter.\n");
+	return -1;
+}
+
+double BcastData(int trialsNum, int elementsNum, int* sendData)
+{
+	if (trialsNum == 0)
+	{
+		return 0;
+	}
+	double totalMPIBcastTime = 0.0;
+
+	int i;
+	for (i = 0; i < trialsNum; i++)
+	{
+		// An MPI barrier completes after all group members have entered the barrier.
+		MPI_Barrier(MPI_COMM_WORLD);
+		// MPI_Wtime returns a floating-point number of seconds, representing elapsed wall-clock time since some time in the past.
+		totalMPIBcastTime -= MPI_Wtime();
+		// MPI_Bcast broadcasts a message from the process with rank root to all processes of the group, itself included.
+		MPI_Bcast(sendData, elementsNum, MPI_INT, 0, MPI_COMM_WORLD);
+		MPI_Barrier(MPI_COMM_WORLD);
+		totalMPIBcastTime += MPI_Wtime();
+	}
+	return totalMPIBcastTime;
+}
+
+int main(int argc, char** argv)
+{
+	if (InputParameterParse(argc, argv) != 0)
+	{
+		return -1;
+	}
+	// Send data numbers.
+	int elementsNum = 10000;
+	int trialsNum = 10;
+	int rankNum;
+	int sizeOfInt = sizeof(int);
+	double totalMPIBcastTime = 0.0;
+	int* sendData = (int*)malloc(sizeof(int) * elementsNum);
+	if (sendData == NULL)
+	{
+		printf("Out of memory.\n");
+		return -1;
+	}
+	memset(sendData, 0, elementsNum);
+
+	// Init.
+	MPI_Init(NULL, NULL);
+	// This function gives the rank of the process in the particular communicator’s group.
+	MPI_Comm_rank(MPI_COMM_WORLD, &rankNum);
+
+	totalMPIBcastTime = BcastData(trialsNum, elementsNum, sendData);
+
+	if (rankNum == 0)
+	{
+		printf("Data size = %d, Trials = %d\n", elementsNum * sizeOfInt, trialsNum);
+		printf("Average of MPI_Bcast time = %lf seconds\n", totalMPIBcastTime / trialsNum);
+	}
+	free(sendData);
+	MPI_Finalize();
+}

--- a/Development_framework/hpc-sdk/examples/kml/blas/CMakeLists.txt
+++ b/Development_framework/hpc-sdk/examples/kml/blas/CMakeLists.txt
@@ -1,0 +1,77 @@
+# Copyright 2022 Huawei Technologies Co., Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 2.8)
+project(kml_blas_demo C)
+
+# Add source files
+set(SRC src/blas_demo.c)
+
+# Set BLAS option
+option(BLAS "This is a default BLAS library nolocking." nolocking)
+
+# Set target file
+set(TARGET_FILE blas_demo)
+
+# Set KML path
+set(KML_PATH /usr/local/kml)
+
+# Set compiler
+set(CMAKE_C_COMPILER mpicc)
+
+# Add header file include directories
+include_directories(${KML_PATH}/include)
+
+# Default build type is debug
+set(CMAKE_BUILD_TYPE "Debug")
+
+# Set conditional compilation
+if(${BLAS} STAREQUAL "omp")
+    message(STATUS "The BLAS version used by demo is: omp.")
+    # Find link library
+    find_library(KBLAS kblas HINTS ${KML_PATH}/lib/kblas/omp)
+    # Add link library
+    link_directories(${KML_PATH}/lib/kblas/omp)   
+elseif(${BLAS} STAREQUAL "locking")
+    message(STATUS "The BLAS version used by demo is: locking.")
+    # Find link library
+    find_library(KBLAS kblas HINTS ${KML_PATH}/lib/kblas/locking)
+    # Add link library
+    link_directories(${KML_PATH}/lib/kblas/locking)
+elseif(${BLAS} STAREQUAL "pthread")
+    message(STATUS "The BLAS version used by demo is: pthread.")
+    # Find link library
+    find_library(KBLAS kblas HINTS ${KML_PATH}/lib/kblas/pthread)
+    # Add link library
+    link_directories(${KML_PATH}/lib/kblas/pthread)
+else()
+    message(STATUS "The BLAS version used by demo is: nolocking.")
+    # Find link library
+    find_library(KBLAS kblas HINTS ${KML_PATH}/lib/kblas/nolocking)
+    # Add link library
+    link_directories(${KML_PATH}/lib/kblas/nolocking)
+endif()
+
+# Set debug compilation option
+if(${CMAKE_BUILD_TYPE} STAREQUAL "Debug")
+    add_compile_options(-g -o0)
+endif()
+
+# Add openmp option
+add_compile_options(-fopenmp)
+
+# Generate execute file
+add_executable(${TARGET_FILE} ${SRC})
+target_link_libraries(${TARGET_FILE} ${KBLAS})
+

--- a/Development_framework/hpc-sdk/examples/kml/blas/README.md
+++ b/Development_framework/hpc-sdk/examples/kml/blas/README.md
@@ -1,0 +1,71 @@
+# **KML_BLAS library functions demo**
+
+简体中文 | [English](README_en.md)
+
+## 介绍
+
+1. BLAS（Basic Linear Algebra
+   Subprograms）提供了一系列基本线性代数运算函数的标准接口，包括矢量线性组合、矩阵乘以矢量、矩阵乘以矩阵等功能。BLAS已被广泛的应用于工业界和科学计算，成为业界标准。[KML_BLAS](https://www.hikunpeng.com/document/detail/zh/kunpengaccel/math-lib/devg-kml/kunpengaccel_kml_16_0012.html)
+   库提供BLAS函数的C语言接口。
+2. **KML_BLAS library functions demo** 展示使用KML_BLAS库函数的代码示例，演示矩阵乘法、对称矩阵乘法、更新对称矩阵轶等函数的使用流程。
+
+## 使用依赖
+
+1. 通过[HPC SDK](https://mirrors.huaweicloud.com/kunpeng/archive/Kunpeng_SDK/HPC/)安装HMPI库，编译器，数学库。
+
+## 使用教程
+
+KML_BLAS有多个版本：
+- 单线程不加锁版本：/usr/local/kml/lib/kblas/nolocking/libkblas.so
+- 单线程加锁版本：/usr/local/kml/lib/kblas/locking/libkblas.so
+- pthread实现多线程版本：/usr/local/kml/lib/kblas/pthread/libkblas.so
+- OpenMP实现多线程版本：/usr/local/kml/lib/kblas/omp/libkblas.so
+
+**Demo中提供CMake编译选项来链接到不同版本的BLAS库**
+
+1. 获取代码
+
+   ```shell
+   git clone https://github.com/kunpengcompute/devkitdemo.git
+   ```
+
+2. 切入到项目根路径
+
+   ```shell
+   cd ./devkitdemo/Development_framework/hpc-sdk/examples/kml/blas/
+   ```
+
+3. 编译demo
+
+   ```shell
+   mkdir build
+   cd build
+   # 默认使用nolocking版本BLAS库
+   cmake ..
+   make
+   # 使用locking版本BLAS库
+   cmake -DBLAS=locking ..
+   make
+   # 使用pthread版本BLAS库
+   cmake -DBLAS=pthread ..
+   make
+   # 使用omp版本BLAS库
+   cmake -DBLAS=omp ..
+   make
+   ```
+
+4. 运行demo
+
+   ```shell
+   # 单独执行
+   ./blas_demo
+   # mpirun 执行
+   mpirun -n rank数 blas_demo
+   ```
+
+5. 清理demo
+
+   ```shell
+   cd ..
+   rm -rf build
+   ```

--- a/Development_framework/hpc-sdk/examples/kml/blas/README_en.md
+++ b/Development_framework/hpc-sdk/examples/kml/blas/README_en.md
@@ -1,0 +1,72 @@
+# **KML_BLAS library functions demo**
+
+English | [简体中文](README.md)
+
+## Introduction
+
+1. Basic Linear Algebra Subprograms (BLAS) provides a series of standard interfaces for basic linear algebra operation
+   functions, including vector linear combination, matrix multiplied by vector, and matrix multiplied by matrix. BLAS
+   has been widely used in industry and scientific computing, and has become an industry standard.
+   The [KML_BLAS](https://www.hikunpeng.com/document/detail/en/kunpengaccel/math-lib/devg-kml/kunpengaccel_kml_16_0012.html)
+   library provides the C language interface for BLAS functions.
+2. The **KML_BLAS library functions demo** shows a code example for KML_BLAS library functions, demonstrates   the use process of matrix multiplication, symmetric matrix multiplication, update the rank of sysmmetric matrix, etc functions.
+
+## Dependencies
+
+1. Using the [HPC SDK](https://mirrors.huaweicloud.com/kunpeng/archive/Kunpeng_SDK/HPC/) to install the HMPI library, compiler, and math library.
+
+## Guidance
+
+There are multiple versions of KML_BLAS:
+- Single-thread version without locking: /usr/local/kml/lib/kblas/nolocking/libkblas.so
+- Single-thread version with locking: /usr/local/kml/lib/kblas/locking/libkblas.so
+- Multi-thread version using pthread: /usr/local/kml/lib/kblas/pthread/libkblas.so
+- Multi-thread version using OpenMP: /usr/local/kml/lib/kblas/omp/libkblas.so
+
+**The CMake compilation option is provided in the demo to link to different versions of the BLAS library.**
+1. Obtain the code.
+
+   ```shell
+   git clone https://github.com/kunpengcompute/devkitdemo.git
+   ```
+
+2. Switch to the project root path.
+
+   ```shell
+   cd ./devkitdemo/Development_framework/hpc-sdk/examples/kml/blas/
+   ```
+
+3. Compile the demo.
+
+   ```shell
+   mkdir build
+   cd build
+   # The BLAS library of the nolocking version is used by default.
+   cmake ..
+   make
+   # Use the BLAS library of the locking version.
+   cmake -DBLAS=locking ..
+   make
+   # Use the BLAS library of the pthread version.
+   cmake -DBLAS=pthread ..
+   make
+   # Use the BLAS library of the omp version.
+   cmake -DBLAS=omp ..
+   make
+   ```
+
+4. Run the demo.
+
+   ```shell
+   # Run the demo independently.
+   ./blas_demo
+   # Run the demo using the mpirun command.
+   mpirun -n rank numbers blas_demo
+   ```
+
+5. Clean up the demo.
+
+   ```shell
+   cd ..
+   rm -rf build
+   ```

--- a/Development_framework/hpc-sdk/examples/kml/blas/src/blas_demo.c
+++ b/Development_framework/hpc-sdk/examples/kml/blas/src/blas_demo.c
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2022 Huawei Technologies Co., Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http: //www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * Description:
+ * 		KML_BLAS library functions demo demonstrates the use process of matrix multiplication, 
+ * 		symmetric matrix multiplication, update the rank of sysmmetric matrix, etc functions.
+ * Create: 2022-05-15
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <memory.h>
+
+#include <kblas.h>
+#include <mpi.h>
+
+void PrintMatrix(int row, int column, const float* matrix)
+{
+	int i;
+	for (i = 0; i < row; i++)
+	{
+		int j;
+		for (j = 0; j < column; j++)
+		{
+			printf("%-12.6f", matrix[j * column + i]);
+		}
+		printf("\n");
+	}
+	printf("\n");
+}
+
+int main()
+{
+	MPI_Init(NULL, NULL);
+	// Rows of matrices of op(A) and C
+	int m = 3;
+	// Columns of matrices of op(B) and C
+	int n = 3;
+	// Columns of the matrix op(A) and rows of the matrix op(B)
+	int k = 3;
+	// If the matrix is column store and TransA = CblasNoTrans, lda is at least max(1, m); otherwise, lda is at least max(1, k).
+	// If A is row-store matrix and TransA = CblasNoTrans, lda is at least max(1, k); otherwise, lda is at least max(1, m).
+	int lda = 3, ldb = 3, ldc = 3;
+	// Multiplication coefficient
+	float alpha = 1.0F, beta = 1.0F;
+
+	float a[9] = { 1.0F, 0, 0,
+	               0, 1.0F, 0,
+	               0, 0, 1.0F };
+	printf("Input matrix A(3*3):\n");
+	PrintMatrix(3, 3, a);
+
+	float b[9] = { 0, 0, 2.0F,
+	               0, 2.0F, 0,
+	               2.0F, 0, 0 };
+	printf("Input matrix B(3*3):\n");
+	PrintMatrix(3, 3, b);
+
+	float c[9] = { 3.0F, 0, 4.0F,
+	               0, 0, 0,
+	               4.0F, 0, 3.0F };
+	printf("Input matrix C(3*3):\n");
+	PrintMatrix(3, 3, c);
+
+	float d[9];
+	memcpy(d, c, sizeof(d));
+
+	/*
+	 * Multiply one matrix by another.
+	 * C = alpha * op(A) * op(B) + beta * C
+	 * The value of op(X) may be op(X) = X, op(X) = X', op(X) = conjg(X')
+	 * alpha and beta are multiplication coefficient.
+	 * op(A) is an m*k matrix, op(B) is a k*n matrix, C is an m*n matrix.
+	 */
+	cblas_sgemm(CblasColMajor, CblasNoTrans, CblasNoTrans, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc);
+	printf("cblas_sgemm --> Output matrix C(3*3):\n");
+	PrintMatrix(m, n, c);
+
+	/*
+	 * Compute the product of matrices in which matrix A is symmetric.
+	 * C = alpha * A * B + beta * C  or  C = alpha * B * A + beta * C
+	 * alpha and beta are multiplication coefficient.
+	 * A is a symmetric matrix, B and C are m*n general matrices.
+	 */
+	cblas_ssymm(CblasColMajor, CblasLeft, CblasLower, m, n, alpha, a, lda, b, ldb, beta, c, ldc);
+	printf("cblas_ssymm --> Output matrix C(3*3):\n");
+	PrintMatrix(m, n, c);
+
+	/*
+	 * Perform a rank-k matrix-matrix operation for a symmetric matrix.
+	 * C = alpha * A * A' + beta * C  or  C = alpha * A' * A + beta * C
+	 * alpha and beta are multiplication coefficient.
+	 * C is an n*n symmetric matrix.
+	 * In the first case, A is an n*k matrix.
+	 * In the second case, A is a k*n general matrix.
+	 */
+	cblas_ssyrk(CblasColMajor, CblasUpper, CblasNoTrans, n, k, alpha, c, lda, beta, d, ldc);
+	printf("cblas_ssyrk --> Output matrix C(3*3):\n");
+	PrintMatrix(m, n, c);
+	MPI_Finalize();
+	return EXIT_SUCCESS;
+}

--- a/Development_framework/hpc-sdk/examples/kml/fft/CMakeLists.txt
+++ b/Development_framework/hpc-sdk/examples/kml/fft/CMakeLists.txt
@@ -1,0 +1,64 @@
+# Copyright 2022 Huawei Technologies Co., Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 2.8)
+project(kml_fft_demo C)
+
+# Add source files
+set(SRC src/fft_demo.c)
+
+# Set FFT option
+option(FFT "This is a default FFT library nolocking." double)
+
+# Set target file
+set(TARGET_FILE fft_demo)
+
+# Set KML path
+set(KML_PATH /usr/local/kml)
+
+# Set compiler
+set(CMAKE_C_COMPILER mpicc)
+
+# Add header file include directories
+include_directories(${KML_PATH}/include)
+
+# Default build type is debug
+set(CMAKE_BUILD_TYPE "Debug")
+
+# Add link library
+link_directories(${KML_PATH}/lib)
+
+# Set conditional compilation
+if(${FFT} STAREQUAL "single")
+    message(STATUS "The FFT version used by demo is: single.")
+    # Find link library
+    find_library(KFFT kfftf HINTS ${KML_PATH}/lib)
+else()
+    message(STATUS "The FFT version used by demo is: double.")
+    # Find link library
+    find_library(KFFT kfft HINTS ${KML_PATH}/lib)
+endif()
+
+# Set debug compilation option
+if(${CMAKE_BUILD_TYPE} STAREQUAL "Debug")
+    add_compile_options(-g -o0)
+endif()
+
+# Add openmp option
+add_compile_options(-fopenmp)
+
+# Generate execute file
+add_executable(${TARGET_FILE} ${SRC})
+target_link_libraries(${TARGET_FILE} ${KFFT})
+

--- a/Development_framework/hpc-sdk/examples/kml/fft/README.md
+++ b/Development_framework/hpc-sdk/examples/kml/fft/README.md
@@ -1,0 +1,61 @@
+# **KML_FFT library functions demo**
+
+简体中文 | [English](README_en.md)
+
+## 介绍
+
+1. [KML_FFT](https://www.hikunpeng.com/document/detail/zh/kunpengaccel/math-lib/devg-kml/kunpengaccel_kml_16_0122.html)
+   是一个快速傅里叶变换(FFT)的数学库。
+2. **KML_FFT library functions demo** 展示使用KML_FFT库函数的代码示例，演示C2C变换等函数的使用流程。
+
+## 使用依赖
+
+1. 通过[HPC SDK](https://mirrors.huaweicloud.com/kunpeng/archive/Kunpeng_SDK/HPC/)安装HMPI库，编译器，数学库。
+
+## 使用教程
+
+KML_FFT有多个版本：
+- 单精度版本：/usr/local/kml/lib/libkfftf.so
+- 双精度版本：/usr/local/kml/lib/libkfft.so
+
+**Demo中提供CMake编译选项来链接到不同版本的FFT库**
+1. 获取代码
+
+   ```shell
+   git clone https://github.com/kunpengcompute/devkitdemo.git
+   ```
+
+2. 切入到项目根路径
+
+   ```shell
+   cd ./devkitdemo/Development_framework/hpc-sdk/examples/kml/fft/
+   ```
+
+3. 编译demo
+
+   ```shell
+   mkdir build
+   cd build
+   # 默认使用双精度版本FFT库
+   cmake ..
+   make
+   # 使用单精度版本FFT
+   cmake -DFFT=single ..
+   make
+   ```
+
+4. 运行demo
+
+   ```shell
+   # 单独执行
+   ./fft_demo
+   # mpirun 执行
+   mpirun -n rank数 fft_demo
+   ```
+
+5. 清理demo
+
+   ```shell
+   cd ..
+   rm -rf build
+   ```

--- a/Development_framework/hpc-sdk/examples/kml/fft/README_en.md
+++ b/Development_framework/hpc-sdk/examples/kml/fft/README_en.md
@@ -1,0 +1,61 @@
+# **KML_FFT library functions demo**
+
+English | [简体中文](README.md)
+
+## Introduction
+
+1. [KML_FFT](https://www.hikunpeng.com/document/detail/en/kunpengaccel/math-lib/devg-kml/kunpengaccel_kml_16_0122.html)
+   is a math library of fast Fourier transform (FFT).
+2. The **KML_FFT library functions demo** shows a code example for KML_FFT library functions, demonstrates the use process of C2C transforms, etc functions.
+
+## Dependencies
+
+1. Using the [HPC SDK](https://mirrors.huaweicloud.com/kunpeng/archive/Kunpeng_SDK/HPC/) to install the HMPI library, compiler, and math library.
+
+## Guidance
+
+There are multiple versions of KML_FFT:
+- Single-precision version: /usr/local/kml/lib/libkfft.so
+- Double-precision version: -L /usr/local/kml/lib/libkfftf.so
+
+**The CMake compilation option is provided in the demo to link to different versions of the FFT library.**
+1. Obtain the code.
+
+   ```shell
+   git clone https://github.com/kunpengcompute/devkitdemo.git
+   ```
+
+2. Switch to the project root path.
+
+   ```shell
+   cd ./devkitdemo/Development_framework/hpc-sdk/examples/kml/fft/
+   ```
+
+3. Compile the demo.
+
+   ```shell
+   mkdir build
+   cd build
+   # The FFT library of the double-precision is used by default.
+   cmake ..
+   make
+   # Use the FFT library of the single-precision version.
+   cmake -DFFT=single ..
+   make
+   ```
+
+4. Run the demo.
+
+   ```shell
+   # Run the demo independently.
+   ./fft_demo
+   # Run the demo using the mpirun command.
+   mpirun -n rank numbers fft_demo
+   ```
+
+5. Clean up the demo.
+
+   ```shell
+   cd ..
+   rm -rf build
+   ```

--- a/Development_framework/hpc-sdk/examples/kml/fft/src/fft_demo.c
+++ b/Development_framework/hpc-sdk/examples/kml/fft/src/fft_demo.c
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2022 Huawei Technologies Co., Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http: //www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * Description: 
+ * 		KML_FFT library functions demo demonstrates the use process of C2C transforms, etc functions.
+ * Create: 2022-05-15
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <kfft.h>
+#include <mpi.h>
+
+void PrintComplex(kml_fft_complex* complex, const int length)
+{
+	printf("{\n");
+	int i;
+	for (i = 0; i < length; i++)
+	{
+		printf("    {%.6f, ", complex[i].r);
+		printf("%.6f}", complex[i].i);
+		if (i != length - 1)
+		{
+			printf(",");
+		}
+		printf("\n");
+	}
+	printf("}\n");
+}
+
+int main()
+{
+	MPI_Init(NULL, NULL);
+	// Dimension of FFT. The constraint is 1 ≤ rank ≤ 3.
+	int rank = 2;
+	// Indicates an array whose dimension is rank, including the size of each dimension in the FFT sequence. 
+	// The constraint is n[i] ≥ 1, for i in 0 to rank - 1.
+	int* n;
+	n = (int*)kml_fft_malloc(sizeof(int) * rank);
+	n[0] = 2;
+	n[1] = 3;
+	double init[6][2] = {{ 120, 0 }, { 8, 8 }, { 0, 0 }, { 0, 16 }, { 0, 16 }, { -8, 8 }};
+
+	kml_fft_complex* in;
+	in = (kml_fft_complex*)kml_fft_malloc(sizeof(kml_fft_complex) * n[0] * n[1]);
+	int i;
+	for (i = 0; i < n[0] * n[1]; i++)
+	{
+		in[i].r = init[i][0];
+		in[i].i = init[i][1];
+	}
+
+	printf("Input complex:\n");
+	PrintComplex(in, n[0] * n[1]);
+
+	kml_fft_complex* out;
+	out = (kml_fft_complex*)kml_fft_malloc(sizeof(kml_fft_complex) * n[0] * n[1]);
+	kml_fft_plan plan;
+
+	/*
+	 * Create a plan for the n-dimensional complex-to-complex (C2C) transform of a single contiguous data sequence.
+	 */
+	plan = kml_fft_plan_dft(rank, n, in, out, KML_FFT_FORWARD, KML_FFT_ESTIMATE);
+	kml_fft_execute_dft(plan, in, out);
+
+	printf("kml_fft_plan_dft --> OutPut complex:\n");
+	PrintComplex(out, n[0] * n[1]);
+
+	/*
+	 * Create a plan for the one-dimensional C2C transform of a single contiguous data sequence.
+	 */
+	plan = kml_fft_plan_dft_1d(n[0], in, out, KML_FFT_FORWARD, KML_FFT_ESTIMATE);
+	kml_fft_execute_dft(plan, in, out);
+
+	printf("kml_fft_plan_dft_1d --> OutPut complex:\n");
+	PrintComplex(out, n[0] * n[1]);
+
+	/*
+	 * Create a plan for the two-dimensional C2C transform of a single contiguous data sequence.
+	 */
+	plan = kml_fft_plan_dft_2d(n[0], n[1], in, out, KML_FFT_FORWARD, KML_FFT_ESTIMATE);
+	kml_fft_execute_dft(plan, in, out);
+
+	printf("kml_fft_plan_dft_2d --> OutPut complex:\n");
+	PrintComplex(out, n[0] * n[1]);
+
+	/*
+	 * Create a plan for the there-dimensional C2C transform of a single contiguous data sequence.
+	 */
+	plan = kml_fft_plan_dft_3d(n[0], n[1], 1, in, out, KML_FFT_FORWARD, KML_FFT_ESTIMATE);
+	kml_fft_execute_dft(plan, in, out);
+
+	printf("kml_fft_plan_dft_3d --> OutPut complex:\n");
+	PrintComplex(out, n[0] * n[1]);
+
+	kml_fft_destroy_plan(plan);
+	kml_fft_free(n);
+	kml_fft_free(in);
+	kml_fft_free(out);
+	MPI_Finalize();
+	return EXIT_SUCCESS;
+}

--- a/Development_framework/hpc-sdk/examples/kml/lapack/CMakeLists.txt
+++ b/Development_framework/hpc-sdk/examples/kml/lapack/CMakeLists.txt
@@ -1,0 +1,53 @@
+# Copyright 2022 Huawei Technologies Co., Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 2.8)
+project(kml_lapack_demo C)
+
+# Add source files
+set(SRC src/lapack_demo.c)
+
+# Set target file
+set(TARGET_FILE lapack_demo)
+
+# Set KML path
+set(KML_PATH /usr/local/kml)
+
+# Set compiler
+set(CMAKE_C_COMPILER mpicc)
+
+# Default build type is debug
+set(CMAKE_BUILD_TYPE "Debug")
+
+# Add header file include directories
+include_directories(${KML_PATH}/include)
+
+# Add link library
+find_library(KLAPACK klapack HINTS ${KML_PATH}/lib)
+find_library(KSERVICE kservice HINTS ${KML_PATH}/lib)
+find_library(LAPACK_ADAPT liblapack_adapt.a HINTS ${KML_PATH}/lib)
+find_library(KBLAS kblas HINTS ${KML_PATH}/lib/kblas/omp)
+
+# Set debug compilation option
+if(${CMAKE_BUILD_TYPE} STAREQUAL "Debug")
+    add_compile_options(-g -o0)
+endif()
+
+# Add openmp option
+add_compile_options(-fopenmp)
+
+# Generate execute file
+add_executable(${TARGET_FILE} ${SRC})
+target_link_libraries(${TARGET_FILE} ${KLAPACK} ${LAPACK_ADAPT} ${KBLAS} gfortran m ${KSERVICE})
+

--- a/Development_framework/hpc-sdk/examples/kml/lapack/README.md
+++ b/Development_framework/hpc-sdk/examples/kml/lapack/README.md
@@ -1,0 +1,52 @@
+# **KML_LAPACK library functions demo**
+
+简体中文 | [English](README_en.md)
+
+## 介绍
+
+1. [KML_LAPACK](https://www.hikunpeng.com/document/detail/zh/kunpengaccel/math-lib/devg-kml/kunpengaccel_kml_16_0203.html)
+   通过分块、求解算法组合、多线程、BLAS接口优化等手段，基于鲲鹏架构对线性代数运算库（Linear Algebra PACKage）的计算效率进行了优化。
+2. **KML_LAPACK library functions demo** 展示使用KML_LAPACK库函数的代码示例，演示矩阵分解、矩阵求逆等函数的使用流程。
+
+## 使用依赖
+
+1. 通过[HPC SDK](https://mirrors.huaweicloud.com/kunpeng/archive/Kunpeng_SDK/HPC/)安装HMPI库，编译器，数学库。
+
+## 使用教程
+
+1. 获取代码
+
+   ```shell
+   git clone https://github.com/kunpengcompute/devkitdemo.git
+   ```
+
+2. 切入到项目根路径
+
+   ```shell
+   cd ./devkitdemo/Development_framework/hpc-sdk/examples/kml/lapack/
+   ```
+
+3. 编译demo
+
+   ```shell
+   mkdir build
+   cd build
+   cmake ..
+   make
+   ```
+
+4. 运行demo
+
+   ```shell
+   # 单独执行
+   ./lapack_demo
+   # mpirun 执行
+   mpirun -n rank数 lapack_demo
+   ```
+
+5. 清理demo
+
+   ```shell
+   cd ..
+   rm -rf build
+   ```

--- a/Development_framework/hpc-sdk/examples/kml/lapack/README_en.md
+++ b/Development_framework/hpc-sdk/examples/kml/lapack/README_en.md
@@ -1,0 +1,53 @@
+# **KML_LAPACK library functions demo**
+
+English | [简体中文](README.md)
+
+## Introduction
+
+1. [KML_LAPACK](https://www.hikunpeng.com/document/detail/en/kunpengaccel/math-lib/devg-kml/kunpengaccel_kml_16_0203.html)
+   optimizes the Linear Algebra PACKage (LAPACK) computing efficiency based on the Kunpeng architecture by means of
+   block division, algorithm combination, multi-thread, and BLAS interface optimization.
+2. The **KML_LAPACK library functions demo** shows a code example for KML_LAPACK library functions, demonstrates the use process of matrix factorization, matrix inversion, etc functions.
+
+## Dependencies
+
+1. Using the [HPC SDK](https://mirrors.huaweicloud.com/kunpeng/archive/Kunpeng_SDK/HPC/) to install the HMPI library, compiler, and math library.
+
+## Guidance
+
+1. Obtain the code.
+
+   ```shell
+   git clone https://github.com/kunpengcompute/devkitdemo.git
+   ```
+
+2. Switch to the project root path.
+
+   ```shell
+   cd ./devkitdemo/Development_framework/hpc-sdk/examples/kml/lapack/
+   ```
+
+3. Compile the demo.
+
+   ```shell
+   mkdir build
+   cd build
+   cmake ..
+   make
+   ```
+
+4. Run the demo.
+
+   ```shell
+   # Run the demo independently.
+   ./lapack_demo
+   # Run the demo using the mpirun command.
+   mpirun -n rank numbers lapack_demo
+   ```
+
+5. Clean up the demo.
+
+   ```shell
+   cd ..
+   rm -rf build
+   ```

--- a/Development_framework/hpc-sdk/examples/kml/lapack/src/lapack_demo.c
+++ b/Development_framework/hpc-sdk/examples/kml/lapack/src/lapack_demo.c
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2022 Huawei Technologies Co., Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http: //www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * Description: 
+ * 		KML_LAPACK library functions demo demonstrates the use process of matrix factorization, 
+ * 		matrix inversion, etc functions
+ * Create: 2022-05-15
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <klapack.h>
+#include <mpi.h>
+
+void PrintArray(const double* array, const int row, const int column)
+{
+	int i;
+	for (i = 0; i < row; i++)
+	{
+		int j;
+		for (j = 0; j < column; j++)
+		{
+			printf("%-12.6f", array[j * column + i]);
+		}
+		printf("\n");
+	}
+	printf("\n");
+}
+
+int TestDgetrf(double* a, int* ipiv, const int m, const int n, const int lda)
+{
+	int info = 0;
+	/*
+	 * Compute the LU factorization of matrix A. This function uses partial pivoting, allowing row interchanges. 
+	 * The operation is defined as A = PLU, where P is a permutation matrix, L is a lower triangular matrix or 
+	 * a lower echelon matrix and the diagonal is 1, and U is an upper triangular matrix or an upper echelon matrix.
+	 */
+	dgetrf_(&m, &n, a, &lda, ipiv, &info);
+	if (info != 0)
+	{
+		if (info > 0)
+		{
+			printf("Error: The value of the -%d-th parameter is invalid.", info);
+		}
+		else
+		{
+			printf("Error: The %d-th element on the diagonal of matrix U is 0. "
+			       "The matrix factorization is complete, but U is singular. As a result, "
+			       "an error of dividing by zero occurs when a system of linear equations is solved.", info);
+		}
+	}
+	return info;
+}
+
+int TestDgetri(double* a, const int* ipiv, const int n, const int lda)
+{
+	/*
+	 * Compute the inverse matrix based on the LU factorization result obtained using ?getrf. 
+	 */
+	int info = 0;
+	// Temporary storage space. After lwork=-1 is called, work[0] is the optimal lwork value.
+	double* work = NULL;
+	double qwork;
+	// Length of the work array
+	int lwork = -1;
+	/* Query optimal work size */
+	dgetri_(&n, a, &lda, ipiv, &qwork, &lwork, &info);
+	if (info != 0)
+	{
+		if (info > 0)
+		{
+			printf("Error: The value of the -%d-th parameter is invalid.", info);
+		}
+		else
+		{
+			printf("Error: The %d-th element on the diagonal of U is 0, and the matrix cannot be inverted.", info);
+		}
+		return info;
+	}
+	lwork = (int)qwork;
+	work = (double*)malloc(sizeof(double) * lwork);
+	/* Calculate inversion */
+	dgetri_(&n, a, &lda, ipiv, work, &lwork, &info);
+	free(work);
+	if (info != 0)
+	{
+		if (info > 0)
+		{
+			printf("Error: The value of the -%d-th parameter is invalid.", info);
+		}
+		else
+		{
+			printf("Error: The %d-th element on the diagonal of U is 0, and the matrix cannot be inverted.", info);
+		}
+		return info;
+	}
+	return info;
+}
+
+int main()
+{
+	MPI_Init(NULL, NULL);
+	// Number of rows in matrix A
+	int m = 4;
+	// Number of columns in matrix A
+	int n = 4;
+	// Leading dimension of the matrix A. lda >= max(1, n).
+	int lda = 4;
+	// An array containing pivot indices obtained from ?getrf. Its length is min(m, n). 
+	// For 1 <= ipiv <= min(m, n), row i and row ipiv[i-1] of the matrix are interchanged during factorization.
+	int ipiv[4];
+
+	/*
+	 * A (stored in column-major):
+	 *  1.80   2.88   2.05  -0.89
+	 *  5.25  -2.95  -0.95  -3.08
+	 *  1.58  -2.69  -2.90  -1.04
+	 * -1.11  -0.66  -0.59   0.80
+	 */
+	double a[16] = { 1.80, 5.25, 1.58, -1.11,
+	                 2.88, -2.95, -2.69, -0.66,
+	                 2.05, -0.95, -2.90, -0.59,
+	                 -0.89, -3.80, -1.04, 0.80 };
+	printf("Input matrix A(4*4):\n");
+	PrintArray(a, m, n);
+
+	if (TestDgetrf(a, ipiv, m, n, lda) != 0)
+	{
+		return EXIT_FAILURE;
+	}
+
+	printf("dgetrf --> Matrix A:\n");
+	PrintArray(a, m, n);
+
+	if (TestDgetri(a, ipiv, n, lda) == 0)
+	{
+		printf("dgetri --> Matrix A:\n");
+		PrintArray(a, m, n);
+	}
+	MPI_Finalize();
+	return EXIT_SUCCESS;
+}

--- a/Development_framework/hpc-sdk/examples/kml/math/CMakeLists.txt
+++ b/Development_framework/hpc-sdk/examples/kml/math/CMakeLists.txt
@@ -1,0 +1,64 @@
+# Copyright 2022 Huawei Technologies Co., Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 2.8)
+project(kml_math_demo C)
+
+# Add source files
+set(SRC src/math_demo.c)
+
+# Set MATH option
+option(MATH "This is a default MATH library performance." performance)
+
+# Set target file
+set(TARGET_FILE math_demo)
+
+# Set KML path
+set(KML_PATH /usr/local/kml)
+
+# Set compiler
+set(CMAKE_C_COMPILER mpicc)
+
+# Add header file include directories
+include_directories(${KML_PATH}/include)
+
+# Default build type is debug
+set(CMAKE_BUILD_TYPE "Debug")
+
+# Add link library
+link_directories(${KML_PATH}/lib)
+
+# Find link library
+find_library(MATH_L m HINTS ${KML_PATH}/lib)
+
+if(${MATH} STAREQUAL "precision")
+    message(STATUS "The MATH version used by demo is: precision.")
+    find_library(KMATH km_l9 HINTS ${KML_PATH}/lib)
+else()
+    message(STATUS "The MATH version used by demo is: performance.")
+    find_library(KMATH km HINTS ${KML_PATH}/lib)
+endif()
+
+# Set debug compilation option
+if(${CMAKE_BUILD_TYPE} STAREQUAL "Debug")
+    add_compile_options(-g -o0)
+endif()
+
+# Add openmp option
+add_compile_options(-fopenmp)
+
+# Generate execute file
+add_executable(${TARGET_FILE} ${SRC})
+target_link_libraries(${TARGET_FILE} ${MATH_L} ${KMATH})
+

--- a/Development_framework/hpc-sdk/examples/kml/math/README.md
+++ b/Development_framework/hpc-sdk/examples/kml/math/README.md
@@ -1,0 +1,61 @@
+# **KML_MATH library functions demo**
+
+简体中文 | [English](README_en.md)
+
+## 介绍
+
+1. [KML_MATH](https://www.hikunpeng.com/document/detail/zh/kunpengaccel/math-lib/devg-kml/kunpengaccel_kml_16_0111.html)
+   是C语言实现的基本数学函数库。
+2. **KML_MATH library functions demo** 展示使用KML_MATH库函数的代码示例，演示三角函数的使用流程。
+
+## 使用依赖
+
+1. 通过[HPC SDK](https://mirrors.huaweicloud.com/kunpeng/archive/Kunpeng_SDK/HPC/)安装HMPI库，编译器，数学库。
+
+## 使用教程
+
+KML_MATH有多个版本：
+- 高性能版本：/usr/local/kml/lib/libkm.so
+- 高精度版本：/usr/local/kml/lib/libkm_l9.so
+
+**Demo中提供CMake编译选项来链接到不同版本的MATH库**
+1. 获取代码
+
+   ```shell
+   git clone https://github.com/kunpengcompute/devkitdemo.git
+   ```
+
+2. 切入到项目根路径
+
+   ```shell
+   cd ./devkitdemo/Development_framework/hpc-sdk/examples/kml/math/
+   ```
+
+3. 编译demo
+
+   ```shell
+   mkdir build
+   cd build
+   # 默认使用高性能版本MATH库
+   cmake ..
+   make
+   # 使用高精度版本MATH库
+   cmake -DMATH=precision ..
+   make
+   ```
+
+4. 运行demo
+
+   ```shell
+   # 单独执行
+   ./math_demo
+   # mpirun 执行
+   mpirun -n rank数 math_demo
+   ```
+
+5. 清理demo
+
+   ```shell
+   cd ..
+   rm -rf build
+   ```

--- a/Development_framework/hpc-sdk/examples/kml/math/README_en.md
+++ b/Development_framework/hpc-sdk/examples/kml/math/README_en.md
@@ -1,0 +1,61 @@
+# **KML_MATH library functions demo**
+
+English | [简体中文](README.md)
+
+## Introduction
+
+1. [KML_MATH](https://www.hikunpeng.com/document/detail/en/kunpengaccel/math-lib/devg-kml/kunpengaccel_kml_16_0111.html)
+   is a basic math function library implemented by the C language.
+2. The **KML_MATH library functions demo** shows a code example for KML_MATH library functions, demonstrates the use process of trigonometric functions.
+
+## Dependencies
+
+1. Using the [HPC SDK](https://mirrors.huaweicloud.com/kunpeng/archive/Kunpeng_SDK/HPC/) to install the HMPI library, compiler, and math library.
+
+## Guidance
+
+There are multiple versions of KML_MATH:
+- High-performance version: /usr/local/kml/lib/libkm.so
+- High-precision version: /usr/local/kml/lib/libkm_l9.so
+
+**The CMake compilation option is provided in the demo to link to different versions of the MATH library.**
+1. Obtain the code.
+
+   ```shell
+   git clone https://github.com/kunpengcompute/devkitdemo.git
+   ```
+
+2. Switch to the project root path.
+
+   ```shell
+   cd ./devkitdemo/Development_framework/hpc-sdk/examples/kml/math/
+   ```
+
+3. Compile the demo.
+
+   ```shell
+   mkdir build
+   cd build
+   # The MATH library of the high-performance version is used by default.
+   cmake ..
+   make
+   # Use the MATH library of the high-precition version.
+   cmake -DMATH=precision ..
+   make
+   ```
+
+4. Run the demo.
+
+   ```shell
+   # Run the demo independently.
+   ./math_demo
+   # Run the demo using the mpirun command.
+   mpirun -n rank numbers math_demo
+   ```
+
+5. Clean up the demo.
+
+   ```shell
+   cd ..
+   rm -rf build
+   ```

--- a/Development_framework/hpc-sdk/examples/kml/math/src/math_demo.c
+++ b/Development_framework/hpc-sdk/examples/kml/math/src/math_demo.c
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 Huawei Technologies Co., Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http: //www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * Description: 
+ * 		KML_MATH library functions demo demonstrates the use process of trigonometric functions.
+ * Create: 2022-05-15
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+
+#include <km.h>
+#include <mpi.h>
+
+int main()
+{
+	MPI_Init(NULL, NULL);
+	double sinx, cosx;
+	sincos(M_PI_4, &sinx, &cosx);
+	printf("Input:\npi/4 = %.14f\n\n", M_PI_4);
+	printf("Output:\nsincos { sin(pi/4) = %.14f, cos(pi/4) = %.14f }\n\n", sinx, cosx);
+	printf("Output:\nasin(sin(pi/4)) = %.14f\n\n", asin(sinx));
+	printf("Output:\nacos(cos(pi/4)) = %.14f\n\n", acos(cosx));
+	MPI_Finalize();
+	return EXIT_SUCCESS;
+}
+

--- a/Development_framework/hpc-sdk/examples/kml/spblas/CMakeLists.txt
+++ b/Development_framework/hpc-sdk/examples/kml/spblas/CMakeLists.txt
@@ -1,0 +1,65 @@
+# Copyright 2022 Huawei Technologies Co., Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 2.8)
+project(kml_spblas_demo C)
+
+# Add source files
+set(SRC src/spblas_demo.c)
+
+# Set SPBLAS option
+option(SPBLAS "This is a default SPBLAS library single." single)
+
+# Set target file
+set(TARGET_FILE spblas_demo)
+
+# Set KML path
+set(KML_PATH /usr/local/kml)
+
+# Set compiler
+set(CMAKE_C_COMPILER mpicc)
+
+# Add header file include directories
+include_directories(${KML_PATH}/include)
+
+# Default build type is debug
+set(CMAKE_BUILD_TYPE "Debug")
+
+# Set conditional compilation
+if(${SPBLAS} STAREQUAL "multi")
+    message(STATUS "The SPBLAS version used by demo is: multi.")
+    # Add link library
+    link_directories(${KML_PATH}/lib/kspblas/multi)
+    # Find link library
+    find_library(KSPBLAS kspblas HINTS ${KML_PATH}/lib/kspblas/multi)
+else()
+    message(STATUS "The SPBLAS version used by demo is: single.")
+    # Add link library
+    link_directories(${KML_PATH}/lib/kspblas/single)
+    # Find link library
+    find_library(KSPBLAS kspblas HINTS ${KML_PATH}/lib/kspblas/single)
+endif()
+
+# Set debug compilation option
+if(${CMAKE_BUILD_TYPE} STAREQUAL "Debug")
+    add_compile_options(-g -o0)
+endif()
+
+# Add openmp option
+add_compile_options(-fopenmp)
+
+# Generate execute file
+add_executable(${TARGET_FILE} ${SRC})
+target_link_libraries(${TARGET_FILE} ${KSPBLAS})
+

--- a/Development_framework/hpc-sdk/examples/kml/spblas/README.md
+++ b/Development_framework/hpc-sdk/examples/kml/spblas/README.md
@@ -1,0 +1,61 @@
+# **KML_SPBLAS library functions demo**
+
+简体中文 | [English](README_en.md)
+
+## 介绍
+
+1. [KML_SPBLAS](https://www.hikunpeng.com/document/detail/zh/kunpengaccel/math-lib/devg-kml/kunpengaccel_kml_16_0067.html)
+   库是稀疏矩阵（Sparse Matrix）的基础代数运算库，稀疏矩阵是指大部分矩阵元素为零的矩阵。
+2. **KML_SPBLAS library functions demo** 展示使用KML_SPBLAS库函数的代码示例，演示系数矩阵与向量计算函数的使用流程。
+
+## 使用依赖
+
+1. 通过[HPC SDK](https://mirrors.huaweicloud.com/kunpeng/archive/Kunpeng_SDK/HPC/)安装HMPI库，编译器，数学库。
+
+## 使用教程
+
+KML_SPBLAS有多个版本：
+- 单线程版本：/usr/local/kml/lib/kspblas/single/libkspblas.so
+- 多线程版本：/usr/local/kml/lib/kspblas/multi/libkspblas.so
+
+**Demo中提供CMake编译选项来链接到不同版本的SPBLAS库**
+1. 获取代码
+
+   ```shell
+   git clone https://github.com/kunpengcompute/devkitdemo.git
+   ```
+
+2. 切入到项目根路径
+
+   ```shell
+   cd ./devkitdemo/Development_framework/hpc-sdk/examples/kml/spblas/
+   ```
+
+3. 编译demo
+
+   ```shell
+   mkdir build
+   cd build
+   # 默认使用单线程版本SPBLAS库
+   cmake ..
+   make
+   # 使用多线程版本SPBLAS库
+   cmake -DSPBLAS=multi ..
+   make
+   ```
+
+4. 运行demo
+
+   ```shell
+   # 单独执行
+   ./spblas_demo
+   # mpirun 执行
+   mpirun -n rank数 spblas_demo
+   ```
+
+5. 清理demo
+
+   ```shell
+   cd ..
+   rm -rf build
+   ```

--- a/Development_framework/hpc-sdk/examples/kml/spblas/README_en.md
+++ b/Development_framework/hpc-sdk/examples/kml/spblas/README_en.md
@@ -1,0 +1,63 @@
+# **KML_SPBLAS library functions demo**
+
+English | [简体中文](README.md)
+
+## Introduction
+
+1. The [KML_SPBLAS](https://www.hikunpeng.com/document/detail/en/kunpengaccel/math-lib/devg-kml/kunpengaccel_kml_16_0067.html)
+library is a basic algebraic operation library of a sparse matrix. The majority of the elements in a sparse matrix are
+zero.
+
+2. The **KML_SPBLAS library functions demo** shows a code example for KML_SPBLAS library functions, demonstrates the use process of sparse matrix and vector calculation function.
+
+## Dependencies
+
+1. Using the [HPC SDK](https://mirrors.huaweicloud.com/kunpeng/archive/Kunpeng_SDK/HPC/) to install the HMPI library, compiler, and math library.
+
+## Guidance
+
+There are multiple versions of KML_SPBLAS:
+- Single-thread version: /usr/local/kml/lib/kspblas/single/libkspblas.so
+- Multi-thread version: /usr/local/kml/lib/kspblas/multi/libkspblas.so
+
+**The CMake compilation option is provided in the demo to link to different versions of the SPBLAS library.**
+1. Obtain the code.
+
+   ```shell
+   git clone https://github.com/kunpengcompute/devkitdemo.git
+   ```
+
+2. Switch to the project root path.
+
+   ```shell
+   cd /devkitdemo/Development_framework/hpc-sdk/examples/kml/spblas/
+   ```
+
+3. Compile the demo.
+
+   ```shell
+   mkdir build
+   cd build
+   # The SPBLAS library of the single-thread version is used by default.
+   cmake ..
+   make
+   # Use the SPBLAS library of the multi-thread version.
+   cmake -DSPBLAS=multi ..
+   make
+   ```
+
+4. Run the demo.
+
+   ```shell
+   # 单独执行
+   ./spblas_demo
+   # mpirun 执行
+   mpirun -n rank数 spblas_demo
+   ```
+
+5. Clean up the demo.
+
+   ```shell
+   cd ..
+   rm -rf build
+   ```

--- a/Development_framework/hpc-sdk/examples/kml/spblas/src/spblas_demo.c
+++ b/Development_framework/hpc-sdk/examples/kml/spblas/src/spblas_demo.c
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2022 Huawei Technologies Co., Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http: //www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * Description: 
+ * 		KML_SPBLAS library functions demo demonstrates the use process of sparse matrix and vector calculation function.
+ * Create: 2022-05-15
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <memory.h>
+
+#include <kspblas.h>
+#include <mpi.h>
+
+void PrintMatrix(int row, int column, const float* matrix)
+{
+	int i;
+	for (i = 0; i < row; i++)
+	{
+		int j;
+		for (j = 0; j < column; j++)
+		{
+			printf("%-12.6f", matrix[j * column + i]);
+		}
+		printf("\n");
+	}
+	printf("\n");
+}
+
+void Print_CSR_To_Matrix(int m, float* values, int values_length,
+	KML_INT* row_offsets, int row_offsets_length,
+	KML_INT* column_indices)
+{
+	int i;
+	for (i = 0; i < row_offsets_length; ++i)
+	{
+		if (row_offsets[i] >= values_length)
+		{
+			break;
+		}
+		float x[m];
+		// Initialize the matrix row array
+		memset(x, 0, m * sizeof(float));
+
+		// Confirm the range of values for each row based on the offset
+		int j;
+		for (j = row_offsets[i]; j < row_offsets[i + 1]; ++j)
+		{
+			x[column_indices[j]] = values[j];
+		}
+
+		// print matrix row array
+		int y;
+		for (y = 0; y < m; ++y)
+		{
+			printf("%.6f\t", x[y]);
+		}
+
+		printf("\n");
+	}
+	printf("\n");
+}
+
+int main()
+{
+	MPI_Init(NULL, NULL);
+	// Record sparse matrices using the 'Compressed Sparse Row Formate (CSR)' storage format
+	// Represents the number of rows and columns of the matrix A(m*m) [Define NNZ (Num-non-zero) as the number of non-zero elements in matrix A]
+	KML_INT m = 4;
+	// Mainly used to record the values of non-zero elements (values) from left to right and top to bottom in the matrix A(m*m), the length of the array is NNZ [Values array]
+	float a[9] = { 2.0F, -3.0F, 7.0F, 1.0F, -6.0F, 8.0F, -4.0F, 5.0F, 9.0F };
+	// Indicates the column indices of the non-zero elements in the matrix A(m*m), the length of the array is NNZ [ColumnIndices array]
+	KML_INT ja[9] = { 1, 2, 4, 3, 4, 1, 3, 4, 1 };
+	// Represents the offset (row offsets) of the matrix A(m*m), the first m elements in the array represent the subscripts of the first non-zero element of each row in the matrix A(m*m) in the Values array, The value of the last item is NNZ, the length of the array is m+1 [RowOffsets array]
+	KML_INT ia[5] = { 1, 4, 6, 9, 10 };
+
+	// Only used by functions that support 0-based matrix indexing [conforms to C indexing specification]
+	KML_INT scsrgemv_ja[9];
+	KML_INT scsrgemv_ia[5];
+
+	int ix;
+	for (ix = 0; ix < 9; ++ix)
+	{
+		scsrgemv_ja[ix] = ja[ix] - 1;
+	}
+
+	int iy;
+	for (iy = 0; iy < 5; ++iy)
+	{
+		scsrgemv_ia[iy] = ia[iy] - 1;
+	}
+
+	// array of vectors x
+	float x[4] = { 1.0F, 3.0F, -2.0F, 5.0F };
+	// array of vectors y
+	float y[4] = { -1.0F, 1.0F, 5.0F, 3.0F };
+
+	printf("Input A(4*4):\n");
+	Print_CSR_To_Matrix(m, a, 9, scsrgemv_ia, 5, scsrgemv_ja);
+	printf("Input x:\n");
+	PrintMatrix(1, m, x);
+	printf("Input y:\n");
+	PrintMatrix(1, m, y);
+
+	// [only supports matrix indices starting from 1]
+	kml_sparse_status_t status_kml_sparse_scsrgemv = kml_sparse_scsrgemv(KML_SPARSE_OPERATION_NON_TRANSPOSE, m, a, ia, ja, x, y);
+	if (status_kml_sparse_scsrgemv == KML_SPARSE_STATUS_SUCCESS)
+	{
+		printf("(kml_sparse_scsrgemv) --> Output y:\n");
+		PrintMatrix(1, m, y);
+	}
+
+	// [only supports matrix indices starting from 1]
+	kml_sparse_status_t status_kml_sparse_scsrsymv = kml_sparse_scsrsymv(KML_SPARSE_FILL_MODE_LOWER, m, a, ia, ja, x, y);
+	if (status_kml_sparse_scsrsymv == KML_SPARSE_STATUS_SUCCESS)
+	{
+		printf("(kml_sparse_scsrsymv) --> Output y:\n");
+		PrintMatrix(1, m, y);
+	}
+
+	// [only supports matrix indices starting from 0]
+	kml_sparse_status_t status_kml_csparse_scsrgemv = kml_csparse_scsrgemv(KML_SPARSE_OPERATION_NON_TRANSPOSE, m, a, scsrgemv_ia, scsrgemv_ja, x, y);
+	if (status_kml_csparse_scsrgemv == KML_SPARSE_STATUS_SUCCESS)
+	{
+		printf("(kml_csparse_scsrgemv) --> Output y:\n");
+		PrintMatrix(1, m, y);
+	}
+	MPI_Finalize();
+	return EXIT_SUCCESS;
+}

--- a/Development_framework/hpc-sdk/module/bisheng_modulefiles
+++ b/Development_framework/hpc-sdk/module/bisheng_modulefiles
@@ -1,0 +1,23 @@
+#%Module1.0
+# Copyright 2022 Huawei Technologies Co., Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#  Bisheng module for use with 'environment-modules' package:
+set version 2.1.0.B010
+set prefix
+setenv BISHENG_DIR $prefix
+
+prepend-path    PATH    $prefix/bin
+prepend-path    LD_LIBRARY_PATH $prefix/lib
+prepend-path    MODULEPATH    $prefix

--- a/Development_framework/hpc-sdk/module/gcc_modulefiles
+++ b/Development_framework/hpc-sdk/module/gcc_modulefiles
@@ -1,0 +1,24 @@
+#%Module1.0
+# Copyright 2022 Huawei Technologies Co., Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#  Gcc module for use with 'environment-module' package:
+set version 10.3.1
+set prefix
+setenv GCC_DIR $prefix
+
+prepend-path    PATH    $prefix/bin
+prepend-path    INCLUDE    $prefix/include
+prepend-path    LD_LIBRARY_PATH $prefix/lib64
+prepend-path    MODULEPATH    $prefix

--- a/Development_framework/hpc-sdk/module/hmpi_modulefiles
+++ b/Development_framework/hpc-sdk/module/hmpi_modulefiles
@@ -1,0 +1,24 @@
+#%Module1.0
+# Copyright 2022 Huawei Technologies Co., Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#  HMPI module for use with 'environment-modules' package:
+conflict mpi
+set version 1.1.1
+set prefix
+
+prepend-path    OPAL_PREFIX    $prefix/ompi
+prepend-path    PATH    $prefix/ompi/bin:$prefix/ucx/bin
+prepend-path    LD_LIBRARY_PATH $prefix/ompi/lib:$prefix/ucx/lib
+prepend-path    INCLUDE    $prefix/ompi/include: $prefix/ucx/include

--- a/Development_framework/hpc-sdk/script/README.md
+++ b/Development_framework/hpc-sdk/script/README.md
@@ -1,0 +1,113 @@
+# **鲲鹏HPC SDK一键式安装脚本使用**
+
+简体中文 | [English](README_en.md)
+
+## 1、介绍
+
+#### 1、自动化安装脚本部署HPC相关软件。包括Hyper-mpi、kml、gcc、毕昇
+
+#### 2、支持自定义路径安装
+
+
+## 2、使用依赖
+
+#### 1、服务器兼容性如下
+
+| OS  | HYPER-MPI  | 毕昇2.1 | GCC  | 数学库   |  
+|----| ----  | ---- | ---- | ----  |
+| centos 7  | Y (GCC= 9.3,毕昇) | Y | Y | Y (GCC >= 7.3) |
+| openEuler20.03 LTS  | Y (毕昇) | Y | Y | Y (GCC >= 7.3) |
+| openEuler20.03 sp1  | N | Y | Y | Y (GCC >= 7.3) |
+| openEuler20.03 sp2  | N | Y | Y | Y (GCC >= 7.3) |
+| openEuler20.03 sp3  | N | Y | Y | Y (GCC >= 7.3) |
+| 麒麟V10 SP1  | Y (GCC = 9.3,毕昇) | Y | Y | N  |
+| 麒麟V10 SP2  | Y (GCC = 9.3,毕昇) | Y | Y | N  |
+| unbuntu18.04  | N | Y | Y | Y (GCC >= 7.3)| 
+| unbuntu20.04  | N | Y | Y | Y (GCC >= 7.3) |
+| UOS 1020e | N | Y | Y | N  |  
+
+说明：以上表中均为aarch64架构;小括号中为GCC、毕昇编译器的版本代表依赖最小版本，表中的Y代表系统支持安装，N代表不支持安装。
+
+#### 2、软件依赖列表
+
+
+|  依赖  | HYPER-MPI  | 毕昇2.1 | GCC  | 数学库   |  
+|  ---- | ----  | ---- | ---- | ----  |
+| gcc  | Y(9.3.0) | Y(>=4.8.5)| N | N |
+| bisheng  | Y | N | N | N  |
+| glibc-devel(libc-dev-bin) | N  | N | Y(>=2.17) | N  |
+| glibc  | N | Y(>=2.17)| Y(>=2.17) | N  |
+| libatomic  | N | Y(>=1.2.0) | N | N  |  
+| libgomp  | N | N | N | Y  |  
+
+说明：以上表中内容为hyper-mpi、数学库、GCC、毕昇编译器安装所需要的依赖，表中的Y代表系统依赖，N代表不依赖。redhat系安裝毕昇编译的rpm包时需确保系统已经安装libgomp。
+
+## 3、使用教程
+
+####  1、获取kunpeng-hpc-xxx-aarc64-linux.tar.gz包  
+[https://mirrors.huaweicloud.com/kunpeng/archive/Kunpeng_SDK/HPC/kunpeng-hpc-1.0.0-aarch64-linux.tar.gz]
+(https://mirrors.huaweicloud.com/kunpeng/archive/Kunpeng_SDK/HPC/kunpeng-hpc-1.0.0-aarch64-linux.tar.gz)
+####  2、执行如下命令进行安装
+```
+tar -xf kunpeng-hpc-xxx-aarch64-linux.tar.gz
+cd kunpeng-hpc-xxx-aarch64-linux/script
+bash install.sh
+```
+#### 3、在执行安装过程中根据提示做相应的操作完成HPC安装  
+#### 4、安装完成后根据提示添加环境变量：如下回显信息这里以gcc为例
+
+> 4.1第一种方式执行下面命令添加环境变量到/etc/profile
+```
+  echo 'export PATH=/opt/gcc/gcc-xxx-aarch64-linux/bin:$PATH' >>/etc/profile
+  echo 'export INCLUDE=/opt/gcc/gcc-xxx-aarch64-linux/include:$INCLUDE' >>/etc/profile
+  echo 'export LD_LIBRARY_PATH=/opt/gcc/gcc-xxx-aarch64-linux/lib64:$LD_LIBRARY_PATH' >>/etc/profile
+  source /etc/profile
+```
+> 4.2 第二种使用module加载module_file使环境变量生效
+```
+  module load /opt/modules/gcc/gcc_modulefiles
+```
+> 4.3 可以通过如下方式使变量永久生效  
+
+> * 1、打开~/.bashrc 文件
+```
+  vim ~/.bashrc  
+```
+> * 2、把下面命令写入到 ~/.bashrc 
+```
+  module use /opt/modules/gcc/
+  module load gcc_modulefiles
+```
+> * 3、保存文件  
+> * 4、执行如下命令让配置生效 
+```
+  source ~/.bashrc
+```
+4.4 运行脚本配置环境变量
+```
+  cd kunpeng-hpc-xxx-aarch64-linux/script
+  bash configure_environment_xxxx.sh
+```
+
+## 4、注意事项
+
+#### 1、安装剩余磁盘空间应满足大于3GB
+#### 2、仅支持在aarch64环境中安装
+
+## 5、卸载软件
+#### 以gcc和kml为例进行说明
+#### 1、打开/etc/profile 或者 ~/.bashrc 检查相关软件二进制文件或者lib文件所在路径 。
+```
+vim /etc/profile（~/.bashrc）
+export LD_LIBRARY_PATH=/usr/local/kml/lib:$LD_LIBRARY_PATH
+...
+export LD_LIBRARY_PATH=/usr/local/kml/lib/kspblas/multi:$LD_LIBRARY_PATH
+export INCLUDE=/opt/gcc/gcc-xxxx-aarch64-linux/include:$INCLUDE
+```
+
+说明：执行上述命令打开/etc/profile（~/.bashrc）可以查看到具体的安装路径为‘/usr/local/kml’ 和 ‘/opt/gcc/gcc-xxxx-aarch64-linux/’
+或者执行env / export 查看软件的安装路径。
+
+#### 2、把/etc/profile 或者 ~/.bashrc中的gcc和kml环境变量删除。
+#### 3、根据1步骤中获取的安装目录，在确认此目录中无其他要保留的文件后进行删除操作。路径中/opt为默认安装路径，若为其他自定义路径请自行替换。
+#### 4、打开新的终端窗口，使修改的环境变量生效。

--- a/Development_framework/hpc-sdk/script/README_en.md
+++ b/Development_framework/hpc-sdk/script/README_en.md
@@ -1,0 +1,110 @@
+# **Kunpeng HPC SDK One-Click Installation Script**
+
+English | [简体中文](README.md)
+
+## 1、Introduction
+
+#### 1、Use the automatic installation script to automatically deploy HPC software, including HYPER-MPI, KML, GCC, and BISHENG.
+
+#### 2、Support installation in a user-defined path.
+
+
+## 2、Dependency
+
+#### 1、The server compatibility is as follows:
+
+|  OS  | HYPER-MPI  | BISHENG 2.1 | GCC  | KML   |  
+|  ---- | ----  | ---- | ---- | ----  |
+| centos 7  | Y (GCC >= 9.3,BISHENG) | Y | Y | Y (GCC >= 7.3) |
+| openEuler20.03 LTS  | Y (BISHNEG) | Y | Y | Y (GCC >= 7.3) |
+| openEuler20.03 sp1  | N | Y | Y | Y (GCC >= 7.3) |
+| openEuler20.03 sp2  | N | Y | Y | Y (GCC >= 7.3) |
+| openEuler20.03 sp3  | N | Y | Y | Y (GCC >= 7.3) |
+| kylin V10 SP1  | Y (GCC >= 9.3,BISHENG) | Y | Y | N  |
+| kylin V10 SP2  | Y (GCC >= 9.3,BISHENG) | Y | Y | N  |
+| unbuntu18.04  | N | Y | Y | Y (GCC >= 7.3)| 
+| unbuntu20.04  | N | Y | Y | Y (GCC >= 7.3) |
+| UOS 1020e | N | Y | Y | N  | 
+
+Note: The OSs listed in the preceding table use the AArch64 architecture. The versions of the GCC and Bisheng Compiler in parentheses indicate the earliest supported versions. Y indicates supported installation and N indicates the installation is not supported.
+
+#### 2、Software dependency list
+
+
+|  Dependency  | HYPER-MPI  | BISHENG2.1 | GCC  | KML   |  
+|  ---- | ----  | ---- | ---- | ----  |
+| gcc  | Y(9.3.0) | Y(>4.8.5)| N | N |
+| bisheng  | Y | N | N | N  |
+| glibc-devel(libc-dev-bin) | N  | N | Y(>2.17) | N  |
+| glibc  | N | Y(>2.17)| Y(>2.17) | N  |
+| libatomic  | N | Y(>=1.2) | N | N  |
+| libgomp  | N | N | N | Y  | 
+
+Note: The preceding table lists the dependencies required for installing the HYPER-MPI, math library, GCC, and Bisheng Compiler. Y indicates required dependency for the software and N indicates the dependency is not required. Before installing the RPM　package compiled by Bisheng in the Red Hat system, ensure that libgomp has been installed in the system.
+
+## 3、Usage Guide
+
+####  1、Obtain the kunpeng-hpc-1.0.0-aarc64-linux.tar.gz package. 
+[https://mirrors.huaweicloud.com/kunpeng/archive/Kunpeng_SDK/HPC/kunpeng-hpc-1.0.0-aarch64-linux.tar.gz]
+(https://mirrors.huaweicloud.com/kunpeng/archive/Kunpeng_SDK/HPC/kunpeng-hpc-1.0.0-aarch64-linux.tar.gz)
+####  2、Run the following commands to install the software:
+```
+tar -xf kunpeng-hpc-xxx-aarch64-linux.tar.gz
+cd kunpeng-hpc-xxx-aarch64-linux/script
+bash install.sh
+```
+#### 3、Perform operations as prompted to install the HPC software. 
+#### 4、After the installation is complete, add environment variables ad prompted. The following command output uses GCC as an example:
+
+>  4.1 Method 1: Add environment variables to /etc/profile.
+```
+  echo 'export PATH=/opt/gcc/gcc-xxx-aarch64-linux/bin:$PATH' >>/etc/profile
+  echo 'export INCLUDE=/opt/gcc/gcc-xxx-aarch64-linux/include:$INCLUDE' >>/etc/profile
+  echo 'export LD_LIBRARY_PATH=/opt/gcc/gcc-xxx-aarch64-linux/lib64:$LD_LIBRARY_PATH' >>/etc/profile
+  source /etc/profile
+```
+>  4.2 Method 2: Use the module command to load module_file for the environment variables to take effect.
+```
+  module load /opt/modules/gcc/gcc_modulefiles
+```
+> 4.3 Method 3: Make the environment variables take effect permanently.
+
+> * 1、Open the ~/.bashrc.
+```
+  vim ~/.bashrc  
+```
+> * 2、Add the following content to the ~/.bashrc file:
+```
+  module use /opt/modules/gcc
+  module load gcc_modulefiles
+```
+> * 3、Save the file.
+> * 4、Make the configuration take effect:
+```
+  source ~/.bashrc
+```
+4.4 Method 4: Run the script to configure environment variables.
+```
+  cd kunpeng-hpc-xxx-aarch64-linux/script
+  bash configure_environment_xxxxx.sh
+```
+## 4、Precautions
+
+#### 1、The free drive space for the installation must be greater than 3 GB.
+#### 2、The installation can be performed only in the AArch64 environment.
+
+## 5、Software Uninstallation
+#### The following uses gcc and kml as an example.
+#### 1、Open /etc/profile or ~/.bashrc to check the directory where the binary or lib files of related software are stored.
+```
+vim /etc/profile（~/.bashrc）
+export LD_LIBRARY_PATH=/usr/local/kml/lib:$LD_LIBRARY_PATH
+...
+export LD_LIBRARY_PATH=/usr/local/kml/lib/kspblas/multi:$LD_LIBRARY_PATH
+export INCLUDE=/opt/gcc/gcc-xxxx-aarch64-linux/include:$INCLUDE
+```
+Note: After you access /etc/profile (~/.bashrc), you can view that the installation paths are /usr/local/kml and /opt/gcc/gcc-xxxx-aarch64-linux/ or Run the 'env / export' command to view the software installation path.
+
+#### 2、Delete environment variables.
+#### 3、In the installation path obtained in  step 1, ensure that there are no other files to be stored in the path, and then delete the installation path. In then path, '/opt' is then default installation path. Replace it if it is a user-defined path.
+#### 4、Open a new terminal window for the modified environment variables to take effect.

--- a/Development_framework/hpc-sdk/script/common_fun.sh
+++ b/Development_framework/hpc-sdk/script/common_fun.sh
@@ -1,0 +1,530 @@
+#!/bin/bash
+
+# Copyright 2022 Huawei Technologies Co., Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ctrl+c
+onCtrlC() {
+  logger "The Ctrl+C exception is triggered." {TIP_COLOR_FAILED}
+  exit 0
+}
+
+# ctrl+z
+onCtrlZ() {
+  logger "The Ctrl+Z exception is triggered." {TIP_COLOR_FAILED}
+  exit 0
+}
+
+# SSH disconnection exception
+onDisconnect() {
+  logger "The SSH connection was disconnected exception is triggered." {TIP_COLOR_FAILED}
+  exit 0
+}
+
+create_log_file() {
+  time_stamp=$(date +%s)
+  # Installation log file name
+  LOG_FILE_NAME="install_hpc_${time_stamp}.log"
+  # Absolute path of log files
+  log_file_of_abspath=${current_dir}/../log/$LOG_FILE_NAME
+  # Create a log file
+  mkdir -p ${current_dir}/../log
+  touch ${log_file_of_abspath}
+}
+
+logger() {
+  local msg="$1"
+  local tip_color=$2
+  local datetime=$(date "+%Y-%m-%d %H:%M:%S")
+  if [[ "${tip_color}" ]] && [[ -z $(echo "${tip_color}" | sed "s/[0-9]//g") ]]; then
+    echo -e "\e[1;${tip_color}m${msg}\e[0m"
+    if [[ "${tip_color}" == "${TIP_COLOR_FAILED}" ]]; then
+      level='ERROR'
+    elif [[ "${tip_color}" == "${TIP_COLOR_WARNING}" ]]; then
+      level='WARNING'
+    else
+      level='INFO'
+    fi
+  else
+    if [[ "${tip_color}" == "ERROR" ]]; then
+      level='ERROR'
+    elif [[ "${tip_color}" == "WARNING" ]]; then
+      level='WARNING'
+    else
+      level='INFO'
+    fi
+  fi
+  if [ -f "${log_file_of_abspath}" ]; then
+    echo "[${datetime}] [${level}] ${msg}" >>${log_file_of_abspath}
+  fi
+}
+
+get_os_name() {
+  # Obtain the os name
+  os_name=$(cat /etc/os-release | grep "PRETTY_NAME" | awk -F '"' '{print $2}')
+  os_name_del_space=${os_name// /}
+  if [[ ${os_name_del_space} =~ "KylinLinuxAdvancedServerV10" ]]; then
+    os_name="KylinLinuxAdvancedServerV10"
+  elif [[ ${os_name_del_space} =~ "Ubuntu20.04" ]]; then
+    os_name="Ubuntu20.04"
+  elif [[ ${os_name_del_space} =~ "Ubuntu18.04" ]]; then
+    os_name="Ubuntu18.04"
+  elif [[ ${os_name_del_space} =~ "CentOSLinux" ]]; then
+    red_os=$(cat /etc/redhat-release)
+    red_os=${red_os// /}
+    [[ ${red_os} =~ "CentOSLinuxrelease7.6.1810" ]] && os_name="CentOSLinuxrelease7.6.1810"
+  else
+    os_name=${os_name_del_space}
+  fi
+}
+
+version_ge() {
+  # Compare the version
+  if [[ "$#" != 2 ]]; then
+    return 1
+  fi
+  test "$(echo "$@" | tr " " "\n" | sort -rV | head -n 1)" == "$1"
+  if [[ "$?" == 0 ]]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+user_customize_path() {
+  # Enter a user-defined path.
+  install_name=$1
+  flag=1
+  while [[ ${flag} == '1' ]]; do
+    logger "For a non-root user, enter the directory on which the user has permission." ${TIP_COLOR_WARNING}
+    read -p "Enter the path for installing ${install_name}(default /opt):" you_path
+    if [[ -z "${you_path}" ]]; then
+      # Default installation path
+      customize_path="/opt"
+    else
+      customize_path="${you_path}"
+    fi
+    check_customize_path "${customize_path}"
+    if [[ "$?" == 0 ]]; then
+      break
+    fi
+  done
+  check_space ${customize_path}
+}
+
+get_install_kml_mode() {
+  # Obtain the dpkg or rpm installation mode of the math library
+  if [[ "${os_name}" =~ "Ubuntu" ]]; then
+    install_package_kind='dpkg'
+  else
+    install_package_kind='rpm'
+  fi
+}
+
+check_customize_path() {
+  # Check whether the entered path is valid [0-9a-zA-Z-_/]
+  customize_path="$1"
+  len_path=${#customize_path}
+  char_max=$(($(getconf SCHAR_MAX) - 59))
+  unset new_customize_path
+  if [[ "${len_path}" -ge "${char_max}" ]]; then
+    logger "The path length exceeds the limit. Enter another one." ${TIP_COLOR_FAILED}
+    return 1
+  fi
+  if echo "${customize_path}" | grep -vqE "^/"; then
+    logger "The path should be an absolute path. Enter another one." ${TIP_COLOR_FAILED}
+    return 1
+  fi
+  ar=($(echo "${customize_path}" | tr '/' ' '))
+  for value in ${ar[*]}; do
+    str_status=$(echo "$value" | tr -d "[a-zA-Z0-9-_]")
+    if [[ -n "$str_status" ]]; then
+      logger "The entered installation path can contain digital alphabets and special characters such as ${ALLOW_STRING} Please enter a correct path and try again." ${TIP_COLOR_FAILED}
+      return 1
+    else
+      new_customize_path=${new_customize_path}/${value}
+    fi
+  done
+  if [ -f ${customize_path} ]; then
+    logger "A file with the same name exists. Enter another one." ${TIP_COLOR_FAILED}
+    return 1
+  fi
+  customize_path=${new_customize_path}
+  [[ -z ${customize_path} ]] && customize_path="/"
+  mark_customize_path_status
+  mkdir -p ${customize_path}
+  [[ ${customize_path} == "/" ]] || customize_path=$(
+    cd ${customize_path}
+    pwd
+  )/
+}
+
+mark_customize_path_status() {
+  if [[ -d ${customize_path} ]]; then
+    customize_path_status=1
+  else
+    valid_customize_path=${customize_path}
+    while [[ ${flag} == 1 ]]; do
+      valid_customize_path=${valid_customize_path%/*}
+      if [ -d ${valid_customize_path} ]; then
+        customize_path_status=2
+        break
+      fi
+      if [ -z ${valid_customize_path} ]; then
+        break
+      fi
+    done
+  fi
+}
+
+check_space() {
+  # Check the drive space
+  customize_path="$1"
+  space_flag=1
+  while [[ ${space_flag} == 1 ]]; do
+    if [[ -d ${customize_path} ]]; then
+      avail_space=$(df -lkP ${customize_path} | awk "NR>1" | awk -F " " '{print $4}')
+      break
+    else
+      customize_path=${customize_path%/*}
+      if [[ -z ${customize_path} ]]; then
+        opt_space=$(df -lkP '/' | awk "NR>1" | awk -F " " '{print $4}')
+        break
+      fi
+    fi
+  done
+  if [[ ${avail_space} -lt ${low_space} ]]; then
+    logger "The disk space of the selected installation directory is insufficient." ${TIP_COLOR_FAILED}
+    logger "Ensure that the available space of the ${customize_path} directory is greater than ${low_space_package_g} GB" ${TIP_COLOR_FAILED}
+    exit 1
+  fi
+}
+
+user_choose() {
+  while_flag=1
+  while [[ ${while_flag} == 1 ]]; do
+    num=${#software_support_list[@]}
+    # Install the software according to the sequence selected by the user.
+    echo -n -e "\e[1;33mEnter the serial number of the software that can be installed. Format: a single digit or 'digits+commas', for example, (1,2,3). To exit the installation, enter no:\e[0m"
+    read -r choose_install
+    # If the length of the entered character string exceeds the upper limit, the system prompts you to enter a new character string.
+    max_length_number=$((2 * ${num} - 1))
+    length_number=$(echo ${choose_install} | wc -L)
+    if [[ ${length_number} -gt ${max_length_number} ]]; then
+      logger "The character string you entered is too long." ${TIP_COLOR_FAILED}
+      continue
+    fi
+    # Only one Hyper MPI can be installed.
+    if [[ "${os_name}" =~ "KylinLinux" ]] || [[ "${os_name}" =~ "CentOSLinux" ]]; then
+      if [[ ${choose_install} =~ "1" ]] && [[ ${choose_install} =~ "2" ]]; then
+        logger "Only one hyper-mpi can be installed." ${TIP_COLOR_FAILED}
+        continue
+      fi
+    fi
+    if [[ ${choose_install} =~ ^[nN]$|^no$ ]]; then
+      logger "Exit installation." ${TIP_COLOR_FAILED}
+      exit 1
+    fi
+    if echo ${choose_install} | grep -qE "([1-$num],){1,$num}[1-$num]$|^[1-$num]$"; then
+      break
+    else
+      logger "Select one or multiple sequences and use commas to separate them." ${TIP_COLOR_FAILED}
+    fi
+  done
+  if [[ ${length_number} -eq 1 ]]; then
+    # Only one is selected by the user.
+    # Display the item that the user selects to install.
+    select_result=${software_support_list[((${choose_install} - 1))]}
+  else
+    # Display repeated user input.
+    choose_install=$(echo ${choose_install} | tr ',' ' ' | xargs -n 1 | sort -u)
+    for i in ${choose_install}; do
+      select_result="$select_result,${software_support_list[(($i - 1))]}"
+    done
+  fi
+  logger "The software you select to install is ${select_result#,}." ${TIP_COLOR_SUCCESS}
+}
+
+show_software_support_list() {
+  # Display the software supported by the current system user.
+  logger "Installation environment check result:" ${TIP_COLOR_CHECKING}
+  if [[ "${software_support_list}" =~ "HMPI" ]]; then
+    logger "The hyper-mpi corresponds to a specific compiler. Install the matched compiler for the hyper-mpi. For example, the compiler corresponding to HMPI-BISHENG is BISHENG." ${TIP_COLOR_ECHO}
+  fi
+  if [[ "${software_support_list}" =~ "KML" ]]; then
+    logger "The KML corresponds to a specific compiler. Install the matched compiler for the KML. For example, the compiler corresponding to KML is GCC." ${TIP_COLOR_ECHO}
+  fi
+  printf "%-16s %-29s %-14s %-20s\n" "SequenceNumber" "Software" "Support" >>${log_file_of_abspath}
+  printf "%-16s %-29s %-14s %-20s\n" "SequenceNumber" "Software" "Support"
+  software_support_list=($(echo ${software_support_list} | tr ' ' ' '))
+  for ((i = 0; i < ${#software_support_list[@]}; i++)); do
+    printf "%-16s %-29s %-20s\n" "$((i + 1))" "${software_support_list[i]}" "${check_result_list[i]}" >>${log_file_of_abspath}
+    printf "%-16s %-29s \033[1;32m%-20s\033[0m\n" "$((i + 1))" "${software_support_list[i]}" "${check_result_list[i]}"
+  done
+}
+
+read_answer() {
+  # Process user interaction operations.
+  ask_question="$*"
+  ask_flag=1
+  while [[ ${ask_flag} == 1 ]]; do
+    read -p "${ask_question} [Y/N]:" you_choose
+    if [[ ${you_choose} =~ ^[Yy]$ ]]; then
+      return 0
+    elif [[ ${you_choose} =~ ^[nN]$ ]]; then
+      return 1
+    else
+      logger 'input error' ${TIP_COLOR_FAILED}
+      continue
+    fi
+  done
+}
+
+
+hand_precondition_mpi() {
+  # Handle the installation exception caused by insufficient environment dependency.
+  if [[ ${#miss_package[@]} -gt 0 ]]; then
+    logger "The $(echo ${miss_package[@]}) dependency is not detected in the environment." ${TIP_COLOR_WARNING}
+    read_answer "The corresponding ${miss_package[@]} is missing or the version is incorrect. Are you sure you want to continue the installation?"
+    if [[ $? != 0 ]]; then
+      logger "Exit the hyper-mpi installation." ${TIP_COLOR_FAILED}
+      return 1
+    fi
+  fi
+  install_hyper_mpi
+}
+
+check_precondition_kml() {
+  # Check the math library dependency.
+  local install_package_kind=$1
+  miss_package_kml=()
+  libc6="/usr/lib64/libc.so.6"
+  libgomp="/usr/lib64/libgomp.so.1"
+  [[ ${install_package_kind} == "dpkg" ]] && libc6="/lib/aarch64-linux-gnu/libc.so.6"
+  [[ ${install_package_kind} == "dpkg" ]] && libgomp="/usr/lib/aarch64-linux-gnu/libgomp.so.1"
+  [[ ! -f ${libc6} ]] && miss_package_kml[${#miss_package_kml[*]}]="libc6"
+  [[ ! -f ${libgomp} ]] && miss_package_kml[${#miss_package_kml[*]}]="libgomp"
+  result=$(command -v nm)
+  if [[ -z ${result} ]]; then
+    miss_package_kml[${#miss_package_kml[*]}]="nm"
+  fi
+}
+
+hand_precondition_kml() {
+  if [[ ${#miss_package_kml[@]} -gt 0 ]]; then
+    logger "The ${miss_package_kml[@]} dependency is not detected in the environment."
+    read_answer "The system does not have dependencies such as ${miss_package_kml[@]} or the version does not meet the requirements. Are you sure you want to continue the installing the KML?"
+    if [[ $? != 0 ]]; then
+      logger "Exit the KML installation." ${TIP_COLOR_FAILED}
+      return 1
+    fi
+  fi
+  if [[ ${kml_install_status} == ${SUCCESS} ]]; then
+    del_math_kml
+    if [[ $? == 1 ]]; then
+      return 1
+    fi
+  fi
+  install_math_kml
+}
+
+check_precondition_compiler() {
+  # Check the compiler dependency.
+  local compiler_type=$1
+  miss_package_bisheng=()
+  miss_package_gcc=()
+  glibc_version=$(ldd --version | grep -Po '\d+.\d+\d+' | head -n 1)
+  version_ge "${glibc_version}" "2.17"
+  if [[ "$?" != 0 ]]; then
+    miss_package_gcc[${#miss_package_gcc[*]}]="GLIBC(>=2.17)"
+    miss_package_bisheng[${#miss_package_bisheng[*]}]="GLIBC(>=2.17)"
+  fi
+  if [[ ${compiler_type} == "gcc" ]]; then
+    if [[ ${install_package_kind} == "rpm" ]]; then
+      glibc_devel_version=$(${install_package_kind} -qa | grep -E "^glibc-devel" | head -n 1 | grep -Po "\d+\.\d+\d+")
+      glibc_devel="glibc-devel(>=2.17)"
+    else
+      glibc_devel_version=$(${install_package_kind} -l | grep "libc-dev-bin" | head -n 1 | grep -Po "\d+\.\d+\d+")
+      glibc_devel="libc-dev-bin(>=2.17)"
+    fi
+    version_ge "${glibc_devel_version}" '2.17'
+    if [[ "$?" != 0 ]]; then
+      miss_package_gcc[${#miss_package_gcc[*]}]="${glibc_devel}"
+    fi
+  fi
+  if [[ ${compiler_type} == "bisheng" ]]; then
+    gcc_version=$(gcc --version 2>&1 | head -n 1 | grep -Po "\d+\.\d+\.\d+" | head -n 1)
+    version_ge "${gcc_version}" '4.8.5'
+    if [[ "$?" != 0 ]]; then
+      miss_package_bisheng[${#miss_package_bisheng[*]}]="gcc(>=4.8.5)"
+    fi
+    libatomic_version=$(ldconfig -v 2>&1 | grep libatomic | awk -F '->' '{print $2}' | grep -Po "\d+\.\d+\.\d+")
+    version_ge "${libatomic_version}" '1.2.0'
+    if [[ "$?" != 0 ]]; then
+      miss_package_bisheng[${#miss_package_bisheng[*]}]="libatomic(>=1.2.0)"
+    fi
+  fi
+}
+
+hand_precondition_compiler() {
+  local compiler_type=$1
+  if [[ ${compiler_type} == "gcc" ]]; then
+    miss_package_compiler=(${miss_package_gcc[*]})
+    compiler_install_status=${gcc_install_status}
+  else
+    miss_package_compiler=(${miss_package_bisheng[*]})
+    compiler_install_status=${bisheng_install_status}
+  fi
+  if [[ ${#miss_package_compiler[@]} -gt 0 ]]; then
+    logger "The ${miss_package_compiler[@]} dependency is nit detected in the environment."
+    read_answer "The system does not have dependencies such as ${miss_package_compiler[@]} or the version does not meet the requirements. Are you sure you want to continue the installing the ${compiler_type^^}?"
+    if [[ $? != 0 ]]; then
+      logger "Exit the ${compiler_type^^} installation." ${TIP_COLOR_FAILED}
+      return 1
+    fi
+  fi
+  install_compiler ${compiler_type}
+  if [[ $? == 1 ]]; then
+    logger "Exit the ${compiler_type^^} installation." ${TIP_COLOR_FAILED}
+    return 1
+  fi
+}
+
+check_install_user() {
+  # Prompt for non-root users
+  current_user=$(whoami)
+  if [[ "${current_user}" != "root" ]]; then
+    logger "The current user is not the root user, run the sudo bash install.sh command." ${TIP_COLOR_WARNING}
+    exit 1
+  fi
+}
+
+check_os_name() {
+  # Check whether the current system supports the installation.
+  get_os_name
+  if [[ ! "${support_os_names}" =~ "${os_name}" ]]; then
+    logger "The system does not support the HPC software." ${TIP_COLOR_FAILED}
+    exit 1
+  fi
+}
+
+check_os_architecture() {
+  if [[ $(uname -m) != "aarch64" ]]; then
+    logger "The system does not support installation. Please select the aarch64 architecture." ${TIP_COLOR_FAILED}
+    exit 1
+  fi
+}
+
+change_directory_owner() {
+  local directory="$1"
+  if [ -d "${directory}" ]; then
+    chown root:root -R ${directory}
+  fi
+}
+
+change_directory_permissions() {
+  local directory="$1"
+  local bin_type="$2"
+  local flag=1
+  local path=''
+  if [[ ${bin_type} ]]; then
+    [[ ${bin_type} == "hyper-mpi" ]] && local software_ompi_bin="${directory}/ompi/bin" && local software_ucx_bin="${directory}/ucx/bin"
+    [[ ${bin_type} == "gcc" ]] && local software_gcc_bin="${directory}/bin" && local software_gcc_gnu_bin="${directory}/aarch64-linux-gnu/bin"
+    [[ ${bin_type} == "bisheng" ]] && local software_bisheng_bin="${directory}/bin"
+  fi
+  if [[ ${customize_path_status} == 1 ]]; then
+    cd ${customize_path}
+  elif [[ ${customize_path_status} == 2 ]]; then
+    if [ -z ${valid_customize_path} ]; then
+      local customize_path_special=${customize_path}
+    else
+      cd ${valid_customize_path}
+      local split_path=$(echo $directory | awk -F "^${valid_customize_path}/" '{print $2}')
+    fi
+  fi
+  if [[ "${split_path}" ]];then
+    local valid_customize_path_split=${valid_customize_path}
+    for path in $(echo ${split_path} | tr '/' ' ');do
+      valid_customize_path_split=${valid_customize_path_split}/${path}
+      chmod 755 ${valid_customize_path_split}
+    done
+  else
+    local delete_last_slashes=${customize_path%%/}
+    for path in $(echo ${directory} | tr '/' ' ');do
+      local chmod_path=${chmod_path}/${path}
+      [[ -z "${customize_path_special}" && ${#delete_last_slashes} -ge ${#chmod_path} ]] && continue || chmod 755 ${chmod_path}
+    done
+  fi
+
+  [[ $(ls -A "${directory}") ]] && chmod 755 -R ${directory}/*
+  find ${directory} -type f | xargs chmod 644
+  [[ ${software_ompi_bin} ]] && find ${software_ompi_bin} -type f | xargs chmod 755
+  [[ ${software_ucx_bin} ]] && find ${software_ucx_bin} -type f | xargs chmod 755
+  [[ ${software_gcc_bin} ]] && find ${software_gcc_bin} -type f | xargs chmod 755
+  [[ ${software_gcc_gnu_bin} ]] && find ${software_gcc_gnu_bin} -type f | xargs chmod 755
+  [[ ${software_bisheng_bin} ]] && find ${software_bisheng_bin} -type f | xargs chmod 755
+}
+
+del_math_kml() {
+  # Delete the original kml environment variables
+  read_answer "Before the installation, the existing software will be uninstalled. Are you sure you want to authorize the script to continue?"
+  if [[ $? != 0 ]];then 
+    logger "Do not install the kml repeatedly." ${TIP_COLOR_ECHO}
+    return 1
+  fi
+  logger "Deleting kml" ${TIP_COLOR_ECHO}
+  if [[ ${install_package_kind} == "rpm" ]]; then
+    $install_package_kind -e "${boost_math_name}"
+  else
+    $install_package_kind -P "${boost_math_name}"
+  fi
+  logger "Deleting kml successfull" ${TIP_COLOR_ECHO}
+}
+
+del_hyper_mpi() {
+  # Delete the original hyper mpi environment variables
+  local hyper_mpi_type="$1"
+  install_hyper_mpi_path="${customize_path}hyper_mpi/${hyper_mpi_type}/${hmpi_package_name}"
+  hyper_mpi_modules_path="${customize_path}modules/${hyper_mpi_type}/hmpi_modulefiles"
+  if [[ -d "${install_hyper_mpi_path}" ]] || [[ -f "${hyper_mpi_modules_path}" ]];then
+    [[ -f "${hyper_mpi_modules_path}" ]] && logger "${hyper_mpi_modules_path} file already exists." ${TIP_COLOR_WARNING}
+    [[ -d "${install_hyper_mpi_path}" ]] && logger "${install_hyper_mpi_path} directory is not empty." ${TIP_COLOR_WARNING}
+    read_answer "Are you sure you want to continue the instation? if yes, ${install_hyper_mpi_path} the directory or ${hyper_mpi_modules_path} file will be overwritten."
+    if [[ $? != 0 ]];then 
+      logger 'Do not install the hyper-mpi repeatedly.' ${TIP_COLOR_ECHO}
+      return 1
+    fi
+    [[ -f "${hyper_mpi_modules_path}" ]] && rm -rf "${hyper_mpi_modules_path}"
+    [[ -d "${install_hyper_mpi_path}" ]] && rm -rf "${install_hyper_mpi_path}"
+    logger "Deleting ${hyper_mpi_type}" ${TIP_COLOR_ECHO}
+  fi
+}
+
+del_compiler() {
+  local compiler_type=$1
+  local compiler_path="${customize_path}${compiler_type}/${compiler_name}"
+  local compiler_modules_path="${customize_path}modules/${compiler_type}_modulefiles"
+  if [[ -f "${compiler_modules_path}" ]] || [[ -d "${compiler_path}" ]];then
+    [[ -f "${compiler_modules_path}" ]] && logger "${compiler_modules_path} file already exists." ${TIP_COLOR_WARNING}
+    [[ -d "${compiler_path}" ]] && logger "${compiler_path} directory is not empty." ${TIP_COLOR_WARNING}
+    read_answer "Are you sure you want to continue the instllation? if yes, the ${compiler_path} directory or ${compiler_modules_path} file will be overwritten."
+    if [[ $? != 0 ]];then 
+      logger "Do not install the ${compiler_type^^} repeatedly." ${TIP_COLOR_ECHO}
+      return 1
+    fi
+    [[ -d "${compiler_path}" ]] && rm -rf ${compiler_path}
+    [[ -f "${compiler_modules_path}" ]] && rm -rf ${compiler_modules_path}
+    logger "Deleting ${compiler_type^^} " ${TIP_COLOR_ECHO}
+  fi
+}

--- a/Development_framework/hpc-sdk/script/configure_environment.sh
+++ b/Development_framework/hpc-sdk/script/configure_environment.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# Copyright 2022 Huawei Technologies Co., Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+compiler_gcc=''
+compiler_gcc_install=''
+compiler_bisheng=''
+compiler_bisheng_install=''
+hyper_mpi_gcc=''
+hyper_mpi_gcc_install=''
+hyper_mpi_bisheng=''
+hyper_mpi_bisheng_install=''
+
+
+configure_env(){
+    # configure env
+    if [[ "${compiler_gcc}${compiler_bisheng}${hyper_mpi_gcc}${hyper_mpi_bisheng}test" == 'test' ]];then
+        echo -e "\e[1;33mYou have not installed any software. Please run the installation script before running the script.\e[0m"
+        exit
+    fi
+    [[ ${hyper_mpi_bisheng} ]] && set_hyper_mpi_env ${hyper_mpi_bisheng_install}
+    [[ ${hyper_mpi_gcc} ]] && set_hyper_mpi_env ${hyper_mpi_gcc_install}
+    [[ ${compiler_gcc} ]] && set_compiler_gcc_env ${compiler_gcc_install}
+    [[ ${compiler_bisheng} ]] && set_compiler_bisheng_env ${compiler_bisheng_install}
+    echo -e "\e[1;33mTo make the related commands take effect, run the following command:\e[0m"
+    if [[ ${hyper_mpi_bisheng} || ${hyper_mpi_gcc} ]];then
+        echo "source ~/.bashrc"
+    fi
+
+    if [[ ${compiler_gcc} || ${compiler_bisheng} ]];then
+        echo "source /etc/profile"
+    fi
+}
+
+set_compiler_gcc_env(){
+    local install_compiler_path=$1
+    echo "export PATH=${install_compiler_path}/${compiler_gcc}/bin:\$PATH" >>/etc/profile
+    echo "export INCLUDE=${install_compiler_path}/${compiler_gcc}/INCLUDE:\$INCLUDE" >>/etc/profile
+    echo "export LD_LIBRARY_PATH=${install_compiler_path}/${compiler_gcc}/lib64:\$LD_LIBRARY_PATH" >>/etc/profile
+}
+
+set_compiler_bisheng_env(){
+    local install_compiler_path=$1
+    echo "export PATH=${install_compiler_path}/${compiler_bisheng}/bin:\$PATH" >>/etc/profile
+    echo "export LD_LIBRARY_PATH=${install_compiler_path}/${compiler_bisheng}/lib:\$LD_LIBRARY_PATH" >>/etc/profile
+
+}
+
+set_hyper_mpi_env(){
+    local install_path=$1
+    echo "hwmpi=${install_path}" >> ~/.bashrc
+    echo 'export OPAL_PREFIX=${hwmpi}/ompi' >> ~/.bashrc
+    echo 'export PATH=${hwmpi}/ompi/bin:${hwmpi}/ucx/bin:$PATH' >> ~/.bashrc
+    echo 'export INCLUDE=${hwmpi}/ompi/include:${hwmpi}/ucx/include:$INCLUDE' >> ~/.bashrc
+    echo 'export LD_LIBRARY_PATH=${hwmpi}/ompi/lib:${hwmpi}/ucx/lib:$LD_LIBRARY_PATH' >> ~/.bashrc
+}
+
+configure_env

--- a/Development_framework/hpc-sdk/script/const.conf
+++ b/Development_framework/hpc-sdk/script/const.conf
@@ -1,0 +1,39 @@
+# Copyright 2022 Huawei Technologies Co., Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# OSs supported by HPC
+SUPPORT_OS_NAME=openEuler20.03(LTS);openEuler20.03(LTS-SP1);openEuler20.03(LTS-SP2);openEuler20.03(LTS-SP3);KylinLinuxAdvancedServerV10;UnionTechOSServer20;CentOSLinuxrelease7.6.1810;Ubuntu20.04;Ubuntu18.04;
+SOFTWARE_TO_BE_INSTALLED=HMPI-GCC;HMPI-BISHENG;BISHENG;GCC;KML;
+KYLINV10_LINUX_HMPI_GCC_NAME=Hyper-MPI_1.1.1_aarch64_KylinV10SP2_gcc9.3.0_MLNX-OFED5.4
+KYLINV10_LINUX_HMPI_BISHENG_NAME=Hyper-MPI_1.1.1_aarch64_KylinV10SP2_Bisheng2.1.0_MLNX-OFED5.4
+CENTOS7.6_LINUX_HMPI_GCC_NAME=Hyper-MPI_1.1.1_aarch64_CentOS7.6_GCC9.3_MLNX-OFED5.0
+CENTOS7.6_LINUX_HMPI_BISHENG_NAME=Hyper-MPI_1.1.1_aarch64_CentOS7.6_Bisheng2.1.0_MLNX-OFED5.0
+OPENEULER20.03_LTS_LINUX_HMPI_BISHENG_NAME=Hyper-MPI_1.1.1_aarch64_OpenEuler20.03-LTS_Bisheng2.1.0_MLNX-OFED5.4
+BISHENG_COMPILER_NAME=bisheng-compiler-2.1.0-aarch64-linux
+GCC_COMPILER_NAME=gcc-10.3.1-2021.09-aarch64-linux
+LIBRARY_MATH_DEB_NAME=boostkit-kml-1.6.0.aarch64
+LIBRARY_MATH_RPM_NAME=boostkit-kml-1.6.0-1.aarch64
+# Color of the terminal input
+TIP_COLOR_FAILED=31
+TIP_COLOR_SUCCESS=32
+TIP_COLOR_WARNING=33
+TIP_COLOR_COMMAND=35
+TIP_COLOR_CHECKING=36
+TIP_COLOR_ECHO=37       
+# The maximum drive space is 3GB
+LOW_SPACE=3145728
+LOW_SPACE_PACKAGE_G=3
+# User-defined path  format
+ALLOW_STRING="_-"
+

--- a/Development_framework/hpc-sdk/script/const.sh
+++ b/Development_framework/hpc-sdk/script/const.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+# Copyright 2022 Huawei Technologies Co., Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Read the configuration file and use it as the global variable of the installation script
+current_dir=$(
+  cd $(dirname $0)
+  pwd
+)
+# Supported OSs
+support_os_names=$(sed '/^SUPPORT_OS_NAME=/!d;s/.*=//;s/\r//' ${current_dir}/const.conf)
+
+declare -A software_support_lists=(["openEuler20.03(LTS)"]="HMPI-BISHENG BISHENG GCC KML"
+  ["openEuler20.03(LTS-SP1)"]="BISHENG GCC KML"
+  ["openEuler20.03(LTS-SP2)"]="BISHENG GCC KML"
+  ["openEuler20.03(LTS-SP3)"]="BISHENG GCC KML"
+  ["KylinLinuxAdvancedServerV10"]="HMPI-GCC HMPI-BISHENG BISHENG GCC"
+  ["UnionTechOSServer20"]="BISHENG GCC"
+  ["CentOSLinuxrelease7.6.1810"]="HMPI-GCC HMPI-BISHENG BISHENG GCC KML"
+  ["Ubuntu20.04"]="BISHENG GCC KML"
+  ["Ubuntu18.04"]="BISHENG GCC KML"
+  ["KylinLinuxAdvancedServerV10_HMPI_GCC"]="${kylinv10_hmpi_gcc_name}"
+  ["KylinLinuxAdvancedServerV10_HMPI_BISHENG"]="${kylinv10_hmpi_bisheng_name}"
+  ["CentOSLinuxrelease7.6.1810_HMPI_GCC"]="${centos7_6_linux_hmpi_gcc_name}"
+  ["CentOSLinuxrelease7.6.1810_HMPI_BISHENG"]="${centos7_6_hmpi_bisheng_name}"
+)
+# Minimum drive size
+low_space=$(sed '/^LOW_SPACE=/!d;s/.*=//;s/\r//' ${current_dir}/const.conf)
+low_space_package_g=$(sed '/^LOW_SPACE_PACKAGE_G=/!d;s/.*=//;s/\r//' ${current_dir}/const.conf)
+# Math library name
+boost_math_name="boostkit-kml"
+boost_math_rpm_name=$(sed '/^LIBRARY_MATH_RPM_NAME=/!d;s/.*=//;s/\r//' ${current_dir}/const.conf)
+boost_math_deb_name=$(sed '/^LIBRARY_MATH_DEB_NAME=/!d;s/.*=//;s/\r//' ${current_dir}/const.conf)
+bisheng_compiler_name=$(sed '/^BISHENG_COMPILER_NAME=/!d;s/.*=//;s/\r//' ${current_dir}/const.conf)
+gcc_compiler_name=$(sed '/^GCC_COMPILER_NAME=/!d;s/.*=//;s/\r//' ${current_dir}/const.conf)
+kylinv10_hmpi_gcc_name=$(sed '/^KYLINV10_LINUX_HMPI_GCC_NAME=/!d;s/.*=//;s/\r//' ${current_dir}/const.conf)
+kylinv10_hmpi_bisheng_name=$(sed '/^KYLINV10_LINUX_HMPI_BISHENG_NAME=/!d;s/.*=//;s/\r//' ${current_dir}/const.conf)
+centos7_6_linux_hmpi_gcc_name=$(sed '/^CENTOS7.6_LINUX_HMPI_GCC_NAME=/!d;s/.*=//;s/\r//' ${current_dir}/const.conf)
+centos7_6_hmpi_bisheng_name=$(sed '/^CENTOS7.6_LINUX_HMPI_BISHENG_NAME=/!d;s/.*=//;s/\r//' ${current_dir}/const.conf)
+openeuler20_03_lts_hmpi_bisheng_name=$(sed '/^OPENEULER20.03_LTS_LINUX_HMPI_BISHENG_NAME=/!d;s/.*=//;s/\r//' ${current_dir}/const.conf)
+hyper_mpi_gcc_package_names=(${kylinv10_hmpi_gcc_name} ${centos7_6_linux_hmpi_gcc_name})
+hyper_mpi_bisheng_package_names=(${kylinv10_hmpi_bisheng_name} ${centos7_6_hmpi_bisheng_name} ${openeuler20_03_lts_hmpi_bisheng_name})
+# List of software to be installed
+software_to_be_installed=$(sed '/^SOFTWARE_TO_BE_INSTALLED=/!d;s/.*=//;s/\r//' ${current_dir}/const.conf)
+# User-defined path rule
+ALLOW_STRING=$(sed '/^ALLOW_STRING=/!d;s/.*=//;s/\r//' ${current_dir}/const.conf)
+# Success or failure status
+SUCCESS=1
+FAILED=0
+# Color processing for terminal output
+TIP_COLOR_FAILED=$(sed '/^TIP_COLOR_FAILED=/!d;s/.*=//;s/\r//' ${current_dir}/const.conf)     # red
+TIP_COLOR_SUCCESS=$(sed '/^TIP_COLOR_SUCCESS=/!d;s/.*=//;s/\r//' ${current_dir}/const.conf)   # green
+TIP_COLOR_WARNING=$(sed '/^TIP_COLOR_WARNING=/!d;s/.*=//;s/\r//' ${current_dir}/const.conf)   # yellow
+TIP_COLOR_COMMAND=$(sed '/^TIP_COLOR_COMMAND=/!d;s/.*=//;s/\r//' ${current_dir}/const.conf)   # purple
+TIP_COLOR_CHECKING=$(sed '/^TIP_COLOR_CHECKING=/!d;s/.*=//;s/\r//' ${current_dir}/const.conf) # blue
+TIP_COLOR_ECHO=$(sed '/^TIP_COLOR_ECHO=/!d;s/.*=//;s/\r//' ${current_dir}/const.conf)         # white

--- a/Development_framework/hpc-sdk/script/install.sh
+++ b/Development_framework/hpc-sdk/script/install.sh
@@ -1,0 +1,497 @@
+#!/bin/bash
+
+# Copyright 2022 Huawei Technologies Co., Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+current_dir=$(
+  cd $(dirname $0)
+  pwd
+)
+source ${current_dir}/const.sh
+source ${current_dir}/common_fun.sh
+install_package_dir=${current_dir}/../package
+module_file_dir=${current_dir}/../module
+time_stamp=$(date +%s)
+# Press ctrl-c to capture terminal disconnection exceptions.
+trap 'onCtrlC' INT
+trap 'onCtrlZ' SIGTSTP
+trap 'onDisconnect' HUP
+
+set_software_status() {
+  # Obtain the installation status of supported software.
+  check_result_list=()
+  suggestion_list=()
+  software_support_list=${software_support_lists["$os_name"]}
+  for software_support in $(echo $software_support_list | tr ' ' ' '); do
+    if [[ ${software_support} =~ ^HMPI-GCC$|^HMPI-BISHENG$|^BISHENG$|^GCC$|^KML$ ]]; then
+      check_result_list[${#check_result_list[*]}]='Y'
+    fi
+  done
+}
+
+get_hyper_mpi_package_name() {
+  # Obtain the HMPI package name.
+  if [[ "${os_name}" =~ "KylinLinux" ]]; then
+    if [[ ${select_result} =~ "HMPI-GCC" ]]; then
+      hmpi_package_name=${kylinv10_hmpi_gcc_name}
+    elif [[ ${select_result} =~ "HMPI-BISHENG" ]]; then
+      hmpi_package_name=${kylinv10_hmpi_bisheng_name}
+    fi
+  elif [[ "${os_name}" =~ "CentOSLinux" ]]; then
+    if [[ ${select_result} =~ "HMPI-GCC" ]]; then
+      hmpi_package_name=${centos7_6_linux_hmpi_gcc_name}
+    elif [[ ${select_result} =~ "HMPI-BISHENG" ]]; then
+      hmpi_package_name=${centos7_6_hmpi_bisheng_name}
+    fi
+  elif [[ "${os_name}" =~ "openEuler20.03" ]]; then
+    if [[ ${select_result} =~ "HMPI-GCC" ]]; then
+      hmpi_package_name=${openeuler20_03_lts_hmpi_gcc_name}
+    elif [[ ${select_result} =~ "HMPI-BISHENG" ]]; then
+      hmpi_package_name=${openeuler20_03_lts_hmpi_bisheng_name}
+    fi
+  fi
+}
+
+check_software_installed() {
+  # Check the installed software
+  case $1 in
+  "HMPI-GCC"|"HMPI-BISHENG")
+    hmpi_gcc_install_status=${FAILED}
+    hmpi_bisheng_install_status=${FAILED}
+    hyper_install_status=${FAILED}
+    which mpirun >/dev/null 2>&1
+    if [[ $? == 0 ]]; then
+      hyper_install_status=${SUCCESS}
+      hmpi_name_string=$(which mpirun | awk -F "/ompi/bin/mpirun" '{print $1}')
+      if [[ "${hyper_mpi_gcc_package_names[@]}" =~ "${hmpi_name_string##*/}" ]];then
+          hmpi_gcc_install_status=${SUCCESS}
+      fi
+      if [[ "${hyper_mpi_bisheng_package_names[@]}" =~ "${hmpi_name_string##*/}" ]];then
+          hmpi_bisheng_install_status=${SUCCESS}
+      fi
+    fi
+    ;;
+  "GCC")
+    if gcc -v 2>&1 | grep -q "Kunpeng gcc 10.3.1-2.0.0.b020"; then
+      gcc_install_status=${SUCCESS}
+    else
+      gcc_install_status=${FAILED}
+      if grep -q "gcc-10.3.1-2021.09-aarch64-linux" /etc/profile; then
+        gcc_install_status=${SUCCESS}
+      fi
+    fi
+    ;;
+  "BISHENG")
+    # clang -v Standard errot output 2>&1
+    check_system_bisheng_status
+    ;;
+  "KML")
+    [[ ${install_package_kind} == "rpm" ]] && result=$(${install_package_kind} -qa ${boost_math_name}) || result=$(${install_package_kind} -l ${boost_math_name})
+    [[ "${result}" ]] && kml_install_status=${SUCCESS} || kml_install_status=${FAILED}
+    ;;
+  esac
+}
+
+check_system_gcc_status() {
+  # Check whether the GCC version in the system is supported.
+  install_reply=$1
+  [[ ${install_reply} == "kml" ]] && gcc_support_version='7.3.0' || gcc_support_version='9.3.0'
+  gcc_version=$(gcc --version 2>&1 | head -n 1 | grep -Po "\d+\.\d+\.\d+" | head -n 1)
+  if [[ ${install_reply} == "kml" ]]; then
+    version_ge ${gcc_version} ${gcc_support_version}
+    [[ "$?" == "0" ]] && gcc_kml_check_status=${SUCCESS} || gcc_kml_check_status=${FAILED}
+  else
+    [[ ${gcc_support_version} == ${gcc_version} ]] && gcc_hmpi_check_status=${SUCCESS} || gcc_hmpi_check_status=${FAILED}
+  fi
+}
+
+check_system_bisheng_status() {
+  # Check whether the Bisheng version in the system is supported.
+  if clang -v 2>&1 | grep -q "HUAWEI BiSheng Compiler 2.1.0.B010 clang version 12.0.0"; then
+    bisheng_check_status=${SUCCESS}
+  else
+    bisheng_check_status=${FAILED}
+    if grep -q "bisheng-compiler-2.1.0-aarch64-linux" /etc/profile; then
+      bisheng_check_status=${SUCCESS}
+    fi
+  fi
+}
+
+set_software_choose_status() {
+  # Set the status of the software selected by the user.
+  [[ "${select_result}" =~ ^GCC*$|,GCC* ]] && gcc_choose_status=${SUCCESS} || gcc_choose_status=${FAILED}
+  [[ "${select_result}" =~ ^BISHENG*$|,BISHENG* ]] && bisheng_choose_status=${SUCCESS} || bisheng_choose_status=${FAILED}
+  [[ "${select_result}" =~ "HMPI-GCC" ]] && hmpi_gcc_choose_status=${SUCCESS} || hmpi_gcc_choose_status=${FAILED}
+  [[ "${select_result}" =~ "HMPI-BISHENG" ]] && hmpi_bisheng_choose_status=${SUCCESS} || hmpi_bisheng_choose_status=${FAILED}
+  [[ "${select_result}" =~ "KML" ]] && kml_choose_status=${SUCCESS} || kml_choose_status=${FAILED}
+}
+
+install_hyper_mpi_env_check() {
+  # Check the hyper mpi installation environment.
+  hmpi_type=$1
+  [[ ${hmpi_type} == "gcc" ]] && hmpi_choose_status=${hmpi_gcc_choose_status} || hmpi_choose_status=${hmpi_bisheng_choose_status}
+  if [[ ${hmpi_choose_status} == ${FAILED} ]]; then
+    return 1
+  fi
+  [[ ${hmpi_type} == "gcc" ]] && hmpi_install_status=${hmpi_gcc_install_status} || hmpi_install_status=${hmpi_bisheng_install_status}
+  [[ ${hmpi_type} == "gcc" ]] && compiler_choose_status=${gcc_choose_status} || compiler_choose_status=${bisheng_choose_status}
+  [[ ${hmpi_type} == "gcc" ]] && compiler_hmpi_check_status=${gcc_hmpi_check_status} || compiler_hmpi_check_status=${bisheng_check_status}
+  logger "Start installing the HMPI-${hmpi_type^^}." ${TIP_COLOR_CHECKING}
+  unset miss_package
+  if [[ ! -f ${install_package_dir}/hyper_mpi/"${hmpi_package_name}.tar.gz" ]]; then
+    logger "The installation package cannot be found." ${TIP_COLOR_SUCCESS}
+    return 1
+  fi
+  if [[ ${hyper_install_status} == ${SUCCESS} ]];then
+    if [[ ${hmpi_gcc_install_status} == ${SUCCESS} ]] && [[ ${hmpi_type} == "gcc" ]];then
+      answer_msg="The HPMI-${hmpi_type^^} already exists. Are you sure you want to continue installing the HPMI-${hmpi_type^^}?"
+    fi
+    if [[ ${hmpi_gcc_install_status} == ${SUCCESS} ]] && [[ ${hmpi_type} == "bisheng" ]];then
+      answer_msg="The HPMI-GCC already exists. Are you sure you want to continue installing the HPMI-${hmpi_type^^}?"
+    fi
+    if [[ ${hmpi_bisheng_install_status} == ${SUCCESS} ]] && [[ ${hmpi_type} == "gcc" ]];then
+      answer_msg="The HPMI-BISHENG already exists. Are you sure you want to continue installing the HPMI-${hmpi_type^^}?"
+    fi
+    if [[ ${hmpi_bisheng_install_status} == ${SUCCESS} ]] && [[ ${hmpi_type} == "bisheng" ]];then
+      answer_msg="The HPMI-${hmpi_type^^} already exists. Are you sure you want to continue installing the HPMI-${hmpi_type^^}?"
+    fi
+    logger "Hyper-mpi is installed in this system" ${TIP_COLOR_WARNING}
+    read_answer "${answer_msg}"
+    if [[ $? != 0 ]]; then
+      logger "Do not install the hyper-mpi repeatedly." ${TIP_COLOR_ECHO}
+      return 1
+    fi
+  fi
+  if [[ ${compiler_hmpi_check_status} == ${SUCCESS} ]]; then
+    hand_precondition_mpi
+    return 0
+  fi
+  [[ ${hmpi_type} == "gcc" ]] && logger "The gcc version must be 9.3.0 in the system where the hmpi-gcc is to be installed" ${TIP_COLOR_WARNING}
+  [[ ${hmpi_type} == "gcc" ]] && miss_package[${#miss_package[*]}]="${hmpi_type}(9.3.0)"
+  hand_precondition_mpi
+}
+
+install_kml_env_check() {
+  # Check the math library
+  if [[ ${kml_choose_status} == ${FAILED} ]]; then
+    return 1
+  fi
+  logger "Start installing the KML." ${TIP_COLOR_CHECKING}
+  check_precondition_kml ${install_package_kind}
+  if [[ ${install_package_kind} == "rpm" ]] && [[ ! -f ${install_package_dir}/kml/${boost_math_rpm_name}.rpm ]]; then
+    logger "The installation package cannot be found." ${TIP_COLOR_SUCCESS}
+    return 1
+  elif [[ ${install_package_kind} == "dpkg" ]] && [[ ! -f ${install_package_dir}/kml/${boost_math_deb_name}.deb ]]; then
+    logger "The installation package cannot be found." ${TIP_COLOR_SUCCESS}
+    return 1
+  fi
+  if [[ ${kml_install_status} == ${SUCCESS} ]]; then
+    logger "The KML already exists. Are you sure you want to continue installing the KML?"
+    read_answer "The KML already exists. Are you sure you want to continue installing the KML?"
+    if [[ $? != 0 ]]; then
+      logger "The KML already exists. Are you sure you want to continue installing the KML? N"
+      logger "Do not install the KML repeatedly." ${TIP_COLOR_FAILED}
+      return 1
+    fi
+  fi
+  if [[ ${gcc_kml_check_status} == ${SUCCESS} ]]; then
+    hand_precondition_kml
+    return 0
+  fi
+  miss_package_kml[${#miss_package_kml[*]}]='gcc(>=7.3.0)'
+  hand_precondition_kml
+}
+
+install_compiler_env_check() {
+  # Check the compiler before installation.
+  local compiler_type=$1
+  [[ ${compiler_type} == "gcc" ]] && compiler_choose_status=${gcc_choose_status} || compiler_choose_status=${bisheng_choose_status}
+  if [[ ${compiler_choose_status} == ${SUCCESS} ]]; then
+    [[ ${compiler_type} == "gcc" ]] && compiler_install_status=${gcc_install_status} || compiler_install_status=${bisheng_check_status}
+    [[ ${compiler_type} == "gcc" ]] && compiler_name=${gcc_compiler_name} || compiler_name=${bisheng_compiler_name}
+    check_precondition_compiler ${compiler_type}
+    logger "Start installing the ${compiler_type^^}." ${TIP_COLOR_CHECKING}
+    if [[ ! -f ${install_package_dir}/${compiler_type}/"${compiler_name}.tar.gz" ]]; then
+      logger "The installation package cannot be found." ${TIP_COLOR_SUCCESS}
+      return 1
+    fi
+    # Check whether the compiler is installed.
+    if [[ ${compiler_install_status} == ${SUCCESS} ]]; then
+      logger "The ${compiler_type^^} already exists. Are you sure you want to continue installing the ${compiler_type^^}?"
+      read_answer "The ${compiler_type^^} already exists. Are you sure you want to continue installing the ${compiler_type^^}?"
+      if [[ $? != 0 ]]; then
+        logger "Do not install the ${compiler_type^^} repeatedly." ${TIP_COLOR_FAILED}
+        return 1
+      fi
+    fi
+    if [[ ${compiler_type} == "gcc" ]];then
+      hand_precondition_compiler "gcc" 
+    else
+      hand_precondition_compiler "bisheng"
+    fi
+    [[ $? == 1 ]] && return 1
+  fi
+  if [[ ${compiler_type} == "gcc" ]]; then
+    # Check whether the GCC in the systecm meets the requirements. If no, add a mark.
+    check_system_gcc_status "kml"
+    check_system_gcc_status "hmpi"
+  else
+    check_system_bisheng_status
+  fi
+}
+
+install_hyper_mpi() {
+  # Install Hyper MPI
+  user_customize_path 'hyper-mpi'
+  logger "You choose to install Hyper MPI in the $(
+    cd ${customize_path}
+    pwd
+  ) directory." ${TIP_COLOR_SUCCESS}
+  cd ${install_package_dir}/hyper_mpi
+  [[ ${hmpi_gcc_choose_status} == 1 ]] && install_hyper_mpi_name="hyper_mpi_gcc"
+  [[ ${hmpi_bisheng_choose_status} == 1 ]] && install_hyper_mpi_name="hyper_mpi_bisheng"
+  del_hyper_mpi "${install_hyper_mpi_name}"
+  if [[ $? == 1 ]];then
+    return 1
+  fi
+  cd ${install_package_dir}/hyper_mpi
+  install_hmpi_path=${customize_path}hyper_mpi/${install_hyper_mpi_name}
+  if [ ! -d "${install_hmpi_path}" ]; then
+    mkdir -p ${install_hmpi_path}
+  fi
+  tar -xf ${hmpi_package_name}.tar.gz -C ${install_hmpi_path}
+  cd ${install_hmpi_path}/${hmpi_package_name}
+  # Suggestions for setting Hyper MPI environment variables
+  command_pwd="  echo 'hwmpi=$PWD' >> ~/.bashrc"
+  command_opal_prefix="  echo 'export OPAL_PREFIX=\${hwmpi}/ompi' >> ~/.bashrc"
+  command_path="  echo 'export PATH=\${hwmpi}/ompi/bin:\${hwmpi}/ucx/bin:\$PATH' >> ~/.bashrc"
+  command_include="  echo 'export INCLUDE=\${hwmpi}/ompi/include:\${hwmpi}/ucx/include:\$INCLUDE' >> ~/.bashrc"
+  command_ld_library_path="  echo 'export LD_LIBRARY_PATH=\${hwmpi}/ompi/lib:\${hwmpi}/ucx/lib:\$LD_LIBRARY_PATH' >> ~/.bashrc"
+  logger "Hyper MPI is installed."
+  if [[ ${hmpi_gcc_choose_status} == 1 ]]; then
+    change_modules "HMPI-GCC"
+    hmpi_gcc_installed=1
+    sed -i "s#hyper_mpi_gcc=.*#hyper_mpi_gcc=${hmpi_package_name}#g" ${current_dir}/configure_environment_${time_stamp}.sh
+    sed -i "s#hyper_mpi_gcc_install=.*#hyper_mpi_gcc_install=${install_hmpi_path}/${hmpi_package_name}#g"  ${current_dir}/configure_environment_${time_stamp}.sh
+  elif [[ ${hmpi_bisheng_choose_status} == 1 ]]; then
+    change_modules "HMPI-BISHENG"
+    hmpi_bisheng_installed=1
+    sed -i "s#hyper_mpi_bisheng=.*#hyper_mpi_bisheng=${hmpi_package_name}#g" ${current_dir}/configure_environment_${time_stamp}.sh
+    sed -i "s#hyper_mpi_bisheng_install=.*#hyper_mpi_bisheng_install=${install_hmpi_path}/${hmpi_package_name}#g"  ${current_dir}/configure_environment_${time_stamp}.sh
+  fi
+  change_directory_owner "${install_hmpi_path}/${hmpi_package_name}"
+  change_directory_permissions "${install_hmpi_path}/${hmpi_package_name}" "hyper-mpi"
+  [[ "${install_hyper_mpi_name}" == "hyper_mpi_bisheng" ]] && install_hyper_mpi_tip="HMPI-BISHENG" || install_hyper_mpi_tip="HMPI-GCC"
+  logger "To make the related commands take effect, run the following command:" ${TIP_COLOR_WARNING}
+  logger "${command_pwd}" ${TIP_COLOR_COMMAND}
+  logger "${command_opal_prefix}" ${TIP_COLOR_COMMAND}
+  logger "${command_path}" ${TIP_COLOR_COMMAND}
+  logger "${command_include}" ${TIP_COLOR_COMMAND}
+  logger "${command_ld_library_path}" ${TIP_COLOR_COMMAND}
+  logger "  source ~/.bashrc" ${TIP_COLOR_COMMAND}
+  logger "Use module set env for ${install_hyper_mpi_tip}" ${TIP_COLOR_SUCCESS}
+  logger "  module load ${show_modulefile_path}" ${TIP_COLOR_COMMAND}
+  logger "The ${install_hyper_mpi_tip} is installed." ${TIP_COLOR_SUCCESS}
+}
+
+install_compiler() {
+  # Install compiler
+  local compiler_type=$1
+  user_customize_path "${compiler_type} compiler"
+  logger "you choose install ${compiler_type} path is $(cd ${customize_path};pwd)" ${TIP_COLOR_SUCCESS}
+  del_compiler "${compiler_type}"
+  if [[ $? == 1 ]];then
+    return 1
+  fi
+  cd ${install_package_dir}/${compiler_type}
+  install_compiler_path=${customize_path}${compiler_type}
+  if [ ! -d ${install_compiler_path} ]; then
+    mkdir -p ${install_compiler_path}
+  fi
+  tar -xf ${compiler_name}.tar.gz -C ${install_compiler_path}
+  cd ${install_compiler_path}/${compiler_name}
+  if [[ ${compiler_type} == "bisheng" ]]; then
+    change_modules "BISHENG"
+    bisheng_installed=1
+    sed -i "s#compiler_bisheng=.*#compiler_bisheng=${compiler_name}#g" ${current_dir}/configure_environment_${time_stamp}.sh
+    sed -i "s#compiler_bisheng_install=.*#compiler_bisheng_install=${install_compiler_path}#g"  ${current_dir}/configure_environment_${time_stamp}.sh
+  else
+    change_modules "GCC"
+    gcc_installed=1
+    sed -i "s#compiler_gcc=.*#compiler_gcc=${compiler_name}#g" ${current_dir}/configure_environment_${time_stamp}.sh
+    sed -i "s#compiler_gcc_install=.*#compiler_gcc_install=${install_compiler_path}#g" ${current_dir}/configure_environment_${time_stamp}.sh
+  fi
+  if [[ ${compiler_type} == "gcc" ]]; then
+    command_env_path="  echo 'export PATH=${install_compiler_path}/${compiler_name}/bin:\$PATH' >>/etc/profile"
+    command_env_include="  echo 'export INCLUDE=${install_compiler_path}/${compiler_name}/INCLUDE:\$INCLUDE' >>/etc/profile"
+    command_env_ld_library_path="  echo 'export LD_LIBRARY_PATH=${install_compiler_path}/${compiler_name}/lib64:\$LD_LIBRARY_PATH' >>/etc/profile"
+    command_module=" module load ${show_modulefile_path}"
+  fi
+  if [[ ${compiler_type} == "bisheng" ]]; then
+    command_env_path="  echo 'export PATH=${install_compiler_path}/${compiler_name}/bin:\$PATH' >>/etc/profile"
+    command_env_ld_library_path="  echo 'export LD_LIBRARY_PATH=${install_compiler_path}/${compiler_name}/lib:\$LD_LIBRARY_PATH' >>/etc/profile"
+    command_module="  module load ${show_modulefile_path}"
+  fi
+  change_directory_owner "${install_compiler_path}/${compiler_name}"
+  change_directory_permissions "${install_compiler_path}/${compiler_name}" "${compiler_type}"
+  logger "To make the related commands take effect, run the following command:" ${TIP_COLOR_WARNING}
+  [[ ${command_env_path} ]] && logger "${command_env_path}" ${TIP_COLOR_COMMAND}
+  [[ ${command_env_include} && ${compiler_type} == "gcc" ]] && logger "${command_env_include}" ${TIP_COLOR_COMMAND}
+  [[ ${command_env_ld_library_path} ]] && logger "${command_env_ld_library_path}" ${TIP_COLOR_COMMAND}
+
+  logger "  source /etc/profile" ${TIP_COLOR_COMMAND}
+  logger "use module set env for $compiler_type" ${TIP_COLOR_SUCCESS}
+  logger "${command_module}" ${TIP_COLOR_COMMAND}
+  logger "The ${compiler_type} Compiler is installed." ${TIP_COLOR_SUCCESS}
+}
+
+install_math_kml() {
+  # Install KML
+  check_space /usr/local
+  if [[ ${install_package_kind} == "rpm" ]]; then
+    $install_package_kind -ivh ${install_package_dir}/kml/${boost_math_rpm_name}.rpm
+  else
+    $install_package_kind -i ${install_package_dir}/kml/${boost_math_deb_name}.deb
+  fi
+  if [[ $? -ne 0 ]];then
+    logger "Failed to install the math library." ${TIP_COLOR_FAILED}
+    return 1
+  fi
+  nm_math_kml
+  if [[ $? -ne 0 ]];then
+    logger "Failed to install the math library." ${TIP_COLOR_FAILED}
+    return 1
+  fi
+  logger "To make the related commands take effect, run the following command: source /etc/profile" ${TIP_COLOR_WARNING}
+  logger "The math library is installed." ${TIP_COLOR_SUCCESS}
+}
+
+nm_math_kml() {
+  # Add math library symbols
+  # /usr/local/kml/lib is the default path for installing the math library.
+  logger "Generating a Complete LAPACK..." ${TIP_COLOR_CHECKING}
+  cp -rf ${install_package_dir}/kml/liblapack_adapt.a /usr/local/kml/lib
+  cp -rf ${install_package_dir}/kml/libblas.a /usr/local/kml/lib
+  cd /usr/local/kml/lib
+  klapack=/usr/local/kml/lib/libklapack.a
+  # get symbols defined both in klapack and netlib lapack
+  nm -g liblapack_adapt.a | grep 'T ' | grep -oP '\K\w+(?=_$)' | sort | uniq >netlib.sym
+  nm -g $klapack | grep 'T ' | grep -oP '\K\w+(?=_$)' | sort | uniq >klapack.sym
+  comm -12 klapack.sym netlib.sym >comm.sym
+
+  # update symbols name of liblapack_adapt.a
+  while read sym; do
+    if ! nm liblapack_adapt.a | grep -qe " T ${sym}_\$"; then
+      continue
+    fi
+    ar x liblapack_adapt.a $sym.f.o >/dev/null 2>&1
+    mv $sym.f.o ${sym}_netlib.f.o
+    objcopy --redefine-sym ${sym}_=${sym}_netlib_ ${sym}_netlib.f.o
+    ar d liblapack_adapt.a ${sym}.f.o >/dev/null 2>&1
+    ar ru liblapack_adapt.a ${sym}_netlib.f.o >/dev/null 2>&1
+    rm ${sym}_netlib.f.o
+  done <comm.sym
+}
+
+change_modules_hmpi(){
+  local hmpi_type="$1"
+  logger "Set modules for HMPI-${hmpi_type^^}." ${TIP_COLOR_ECHO}
+  # Original module content
+  old_msg=$(sed -n '/set prefix/p' ${module_file_dir}/hmpi_modulefiles)
+  sed -i s"#${old_msg}#set prefix $(cd ${install_hmpi_path};pwd)/${hmpi_package_name}#" ${module_file_dir}/hmpi_modulefiles
+  if [ ! -d ${customize_path}/modules/hyper_mpi_${hmpi_type} ]; then
+    mkdir -p ${customize_path}/modules/hyper_mpi_${hmpi_type}
+  fi
+  cp -rf ${module_file_dir}/hmpi_modulefiles ${customize_path}/modules/hyper_mpi_${hmpi_type}/
+  show_modulefile_path=${customize_path}modules/hyper_mpi_${hmpi_type}/hmpi_modulefiles
+  logger "The path of HMPI-${hmpi_type^^} modules is ${show_modulefile_path}." ${TIP_COLOR_ECHO}
+}
+
+change_modules_compiler(){
+  local compiler_type="$1"
+  logger "Set modules for ${compiler_type^^}." ${TIP_COLOR_ECHO}
+  old_msg=$(sed -n '/set prefix/p' ${module_file_dir}/${compiler_type}_modulefiles)
+  sed -i s"#${old_msg}#set prefix $(
+    cd ${install_compiler_path}
+    pwd
+  )/${compiler_name}#" ${module_file_dir}/${compiler_type}_modulefiles
+  if [ ! -d ${customize_path}/modules/${compiler_type} ]; then
+    mkdir -p ${customize_path}/modules/${compiler_type}
+  fi
+  cp -rf ${module_file_dir}/${compiler_type}_modulefiles ${customize_path}/modules/${compiler_type}
+  show_modulefile_path=${customize_path}modules/${compiler_type}/${compiler_type}_modulefiles
+  logger "The path of ${compiler_type^^} modules is ${show_modulefile_path}." ${TIP_COLOR_ECHO}
+}
+
+change_modules() {
+  # Modify 'modules file'
+  install_software=$1
+  case $install_software in
+  "HMPI-GCC")
+    change_modules_hmpi "gcc"
+    ;;
+  "HMPI-BISHENG")
+    change_modules_hmpi "bisheng"
+    ;;
+  "BISHENG")
+    change_modules_compiler "bisheng"
+    ;;
+  "GCC")
+    change_modules_compiler "gcc"
+    ;;
+  esac
+  change_directory_owner "${customize_path}modules"
+  change_directory_permissions "${customize_path}modules"
+}
+
+check_environment(){
+  # Checking the Environment
+  check_install_user
+  create_log_file
+  logger "Start installing the HPC software." ${TIP_COLOR_ECHO}
+  logger "Do not press Ctrl+Z or Ctrl+C or restart the system during the installation." ${TIP_COLOR_WARNING}
+  check_os_architecture
+  check_os_name
+}
+
+install_main() {
+  check_environment
+  # Handles software support installation lists and user interacation.
+  get_install_kml_mode
+  set_software_status
+  show_software_support_list
+  user_choose
+  get_hyper_mpi_package_name
+  for result in $(echo ${select_result} | tr ',' ' '); do
+    check_software_installed $result
+  done
+  cp ${current_dir}/configure_environment.sh ${current_dir}/configure_environment_${time_stamp}.sh
+
+  # Handle the software installation process. 
+  set_software_choose_status
+  install_compiler_env_check "gcc"
+  install_compiler_env_check "bisheng"
+  install_hyper_mpi_env_check "gcc"
+  install_hyper_mpi_env_check "bisheng"
+  install_kml_env_check
+  if [[ "${gcc_installed}${bisheng_installed}${hmpi_bisheng_installed}${hmpi_gcc_installed}" =~ '1' ]];then
+    # Execute the script for configuring environment variables.
+    echo -e "\e[1;33mRun the script ${current_dir}/configure_environment_${time_stamp}.sh to configure environment variables.\e[0m"
+  else
+    [[ -f "${current_dir}/configure_environment_${time_stamp}.sh" ]] && rm -f "${current_dir}/configure_environment_${time_stamp}.sh"
+  fi
+  exit 0
+}
+
+install_main


### PR DESCRIPTION
1、增加数学库使用，将不同版本的数学库通过cmake编译选项链接使用
2、demo中引入mpi.h，支持mpirun执行
3、修改位置，将hpc相关移到开发框架目录下